### PR TITLE
Add support for HTTPS_PROXY env variable

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -385,7 +385,7 @@ int MeshAgent_GetSystemProxy(MeshAgentHostContainer *agent, char *buffer, size_t
 			int i = ILibString_IndexOf(*env, envLen, "=", 1);
 			if (i > 0)
 			{
-				if (i == 11 && strncmp(*env, "https_proxy", 11) == 0)
+				if (i == 11 && (strncmp(*env, "https_proxy", 11) == 0 || strncmp(*env, "HTTPS_PROXY", 11) == 0))
 				{
 					if (ILibString_StartsWith(*env + i + 1, envLen - i - 1, "http://", 7) != 0)
 					{


### PR DESCRIPTION
Uppercase version of the variable is often used nowadays, when Googling using HTTP proxies with systemd, the first match from docker.com uses the uppercase version, it might be useful to support both