### PR TITLE
Fix agent crash on ARM64 (Raspberry Pi)

### DIFF
--- a/microscript/ILibDuktape_Commit.h
+++ b/microscript/ILibDuktape_Commit.h
@@ -1,5 +1,3 @@
-// This file is auto-generated, any edits may be overwritten 
-#define SOURCE_COMMIT_DATE "2022-Aug-24 00:54:18-0700"  
-#define SOURCE_COMMIT_DATE "2022-Aug-24 00:54:18-0700"  
-#define SOURCE_COMMIT_HASH "4d1dc7a08244d71ff2838955797dcf59eddd3fe1"  
-#define SOURCE_COMMIT_HASH "4d1dc7a08244d71ff2838955797dcf59eddd3fe1"  
+// This file is auto-generated, any edits may be overwritten
+#define SOURCE_COMMIT_DATE "2023-Apr-14 13:29:41-0700"
+#define SOURCE_COMMIT_HASH "ca52306f87407a122fac70723bfa025b9c422ae6"

--- a/microstack/ILibWebClient.c
+++ b/microstack/ILibWebClient.c
@@ -1360,7 +1360,9 @@ int ILibWebClient_ProcessWebSocketData(char* buffer, int offset, int length, ILi
 		} 
 		else
 		{
-			unsigned long long v = ILibNTOHLL(((unsigned long long*)(buffer + offset + 2))[0]);
+			unsigned long long v;
+			memcpy(&v, buffer + offset + 2, sizeof(v));
+			v = ILibNTOHLL(v);
 			if(v > 0x7FFFFFFFUL)
 			{
 				// this value is too big to store in a 32 bit signed variable, so disconnect the websocket.


### PR DESCRIPTION
The function ILibWebClient_ProcessWebSocketData in microstack/ILibWebClient.c reads a 64-bit integer from an address that is only 2-byte aligned. ARM64 kernels support unaligned accesses from userspace, but it is not enabled by default and frowned upon - the required exception handling is ugly and inefficient.

Fix that illegal access in a simple way with a memcpy. More involved and efficient solutions are also available, such as replacing the byte order conversion functions with de/serialise functions that take a pointer.

Fixes: https://github.com/Ylianst/MeshAgent/issues/183