### PR TITLE
Fix-sysinfo

### DIFF
--- a/modules/identifiers.js
+++ b/modules/identifiers.js
@@ -430,48 +430,66 @@ function windows_identifiers()
     var items, item, i;
 
     var values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_Bios", ['ReleaseDate', 'Manufacturer', 'SMBIOSBIOSVersion', 'SerialNumber']);
-    ret['identifiers'] = {};
-    ret['identifiers']['bios_date'] = values[0]['ReleaseDate'];
-    ret['identifiers']['bios_vendor'] = values[0]['Manufacturer'];
-    ret['identifiers']['bios_version'] = values[0]['SMBIOSBIOSVersion'];
-    ret['identifiers']['bios_serial'] = values[0]['SerialNumber'];
-    ret['identifiers']['bios_mode'] = 'Legacy';
+    if(values[0]){
+        ret['identifiers'] = {};
+        ret['identifiers']['bios_date'] = values[0]['ReleaseDate'];
+        ret['identifiers']['bios_vendor'] = values[0]['Manufacturer'];
+        ret['identifiers']['bios_version'] = values[0]['SMBIOSBIOSVersion'];
+        ret['identifiers']['bios_serial'] = values[0]['SerialNumber'];
+        ret['identifiers']['bios_mode'] = 'Legacy';
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_BaseBoard", ['Product', 'SerialNumber', 'Manufacturer', 'Version']);
-    ret['identifiers']['board_name'] = values[0]['Product'];
-    ret['identifiers']['board_serial'] = values[0]['SerialNumber'];
-    ret['identifiers']['board_vendor'] = values[0]['Manufacturer'];
-    ret['identifiers']['board_version'] = values[0]['Version'];
+    if(values[0]){
+        ret['identifiers']['board_name'] = values[0]['Product'];
+        ret['identifiers']['board_serial'] = values[0]['SerialNumber'];
+        ret['identifiers']['board_vendor'] = values[0]['Manufacturer'];
+        ret['identifiers']['board_version'] = values[0]['Version'];
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_ComputerSystemProduct", ['UUID']);
-    ret['identifiers']['product_uuid'] = values[0]['UUID'];
-    trimIdentifiers(ret.identifiers);
+    if(values[0]){
+        ret['identifiers']['product_uuid'] = values[0]['UUID'];
+        trimIdentifiers(ret.identifiers);
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_PhysicalMemory");
-    trimResults(values);
-    ret.windows.memory = values;
+    if(values[0]){
+        trimResults(values);
+        ret.windows.memory = values;
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_OperatingSystem");
-    trimResults(values);
-    ret.windows.osinfo = values[0];
+    if(values[0]){
+        trimResults(values);
+        ret.windows.osinfo = values[0];
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_DiskPartition");
-    trimResults(values);
-    ret.windows.partitions = values;
-    for (var i in values) {
-        if (values[i].Description=='GPT: System') {
-            ret['identifiers']['bios_mode'] = 'UEFI';
+    if(values[0]){
+        trimResults(values);
+        ret.windows.partitions = values;
+        for (var i in values) {
+            if (values[i].Description=='GPT: System') {
+                ret['identifiers']['bios_mode'] = 'UEFI';
+            }
         }
     }
     
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_Processor", ['Caption', 'DeviceID', 'Manufacturer', 'MaxClockSpeed', 'Name', 'SocketDesignation']);
-    ret.windows.cpu = values;
+    if(values[0]){
+        ret.windows.cpu = values;
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_VideoController", ['Name', 'CurrentHorizontalResolution', 'CurrentVerticalResolution']);
-    ret.windows.gpu = values;
+    if(values[0]){
+        ret.windows.gpu = values;
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_DiskDrive", ['Caption', 'DeviceID', 'Model', 'Partitions', 'Size']);
-    ret.windows.drives = values;
+    if(values[0]){
+        ret.windows.drives = values;
+    }
 
     values = require('win-wmi').query('ROOT\\CIMV2\\Security\\MicrosoftTpm', "SELECT * FROM Win32_Tpm", ['IsActivated_InitialValue','IsEnabled_InitialValue','IsOwned_InitialValue','ManufacturerIdTxt','ManufacturerVersion','ManufacturerVersionInfo','PhysicalPresenceVersionInfo','SpecVersion']);
     if(values[0]) {

--- a/modules/identifiers.js
+++ b/modules/identifiers.js
@@ -429,9 +429,10 @@ function windows_identifiers()
     var ret = { windows: {} };
     var items, item, i;
 
+    ret['identifiers'] = {};
+
     var values = require('win-wmi').query('ROOT\\CIMV2', "SELECT * FROM Win32_Bios", ['ReleaseDate', 'Manufacturer', 'SMBIOSBIOSVersion', 'SerialNumber']);
     if(values[0]){
-        ret['identifiers'] = {};
         ret['identifiers']['bios_date'] = values[0]['ReleaseDate'];
         ret['identifiers']['bios_vendor'] = values[0]['Manufacturer'];
         ret['identifiers']['bios_version'] = values[0]['SMBIOSBIOSVersion'];

--- a/modules/identifiers.js
+++ b/modules/identifiers.js
@@ -492,7 +492,6 @@ function windows_identifiers()
         ret.windows.drives = values;
     }
 
-    
     // Insert GPU names
     ret.identifiers.gpu_name = [];
     for (var gpuinfo in ret.windows.gpu)

--- a/modules/identifiers.js
+++ b/modules/identifiers.js
@@ -492,10 +492,6 @@ function windows_identifiers()
         ret.windows.drives = values;
     }
 
-    values = require('win-wmi').query('ROOT\\CIMV2\\Security\\MicrosoftTpm', "SELECT * FROM Win32_Tpm", ['IsActivated_InitialValue','IsEnabled_InitialValue','IsOwned_InitialValue','ManufacturerIdTxt','ManufacturerVersion','ManufacturerVersionInfo','PhysicalPresenceVersionInfo','SpecVersion']);
-    if(values[0]) {
-        ret.tpm = values;
-    }
     
     // Insert GPU names
     ret.identifiers.gpu_name = [];


### PR DESCRIPTION
Fixes virtual machine detections as some wmi values might be blank

also adds extra identifiers for windows/linux

Signed-off-by: Simon Smith <simonsmith5521@gmail.com>