### PR TITLE
FIX KVM Permission Status for macOS

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4490,7 +4490,7 @@ void agentDumpKeysSink(ILibSimpleDataStore sender, char* Key, int KeyLen, void *
 MeshAgentHostContainer* MeshAgent_Create(MeshCommand_AuthInfo_CapabilitiesMask capabilities)
 {
 
-#if defined(_LINKVM) && defined(_POSIX) && !defined(__APPLE__)
+#if defined(_LINKVM) && defined(__APPLE__)
     //Before anything, check for permissions (macos requirement)
     kvm_check_permission();
 #endif


### PR DESCRIPTION
Fix ARCH comparison, it was using Linux instead of macOS.