### PR TITLE
Fix-#220-Notifybar-does-not-close-on-Linux-when-disconnected

### DIFF
--- a/modules/notifybar-desktop.js
+++ b/modules/notifybar-desktop.js
@@ -562,6 +562,8 @@ function x_notifybar(title)
         .createEvent('close')
         .addMethod('close', function close()
         {
+            require('monitor-info')._X11.XDestroyWindow( this._windows.peek().display, this._windows.peek().notifybar );
+            require('monitor-info')._X11.XFlush( this._windows.peek().display );
         });
 
     ret._promise.createBars = function (m)
@@ -589,15 +591,14 @@ function x_notifybar(title)
             require('monitor-info').hideWindowIcon(m[i].display, this.notifybar._windows.peek().root, this.notifybar._windows.peek().notifybar);
 
             require('monitor-info').setAllowedActions(m[i].display, this.notifybar._windows.peek().notifybar, require('monitor-info').MOTIF_FLAGS.MWM_FUNC_CLOSE);
-            require('monitor-info').setAlwaysOnTop(m[i].display, this.notifybar._windows.peek().root, this.notifybar._windows.peek().notifybar);
-
-
+            
             var wm_delete_window_atom = require('monitor-info')._X11.XInternAtom(m[i].display, require('_GenericMarshal').CreateVariable('WM_DELETE_WINDOW'), 0).Val;
             var atoms = require('_GenericMarshal').CreateVariable(4);
             atoms.toBuffer().writeUInt32LE(wm_delete_window_atom);
             require('monitor-info')._X11.XSetWMProtocols(m[i].display, this.notifybar._windows.peek().notifybar, atoms, 1);
 
             require('monitor-info')._X11.XMapWindow(m[i].display, this.notifybar._windows.peek().notifybar);
+            require('monitor-info').setAlwaysOnTop(m[i].display, this.notifybar._windows.peek().root, this.notifybar._windows.peek().notifybar);
             require('monitor-info')._X11.XFlush(m[i].display);
 
             this.notifybar._windows.peek().DescriptorEvent = require('DescriptorEvents').addDescriptor(require('monitor-info')._X11.XConnectionNumber(m[i].display).Val, { readset: true });
@@ -616,9 +617,7 @@ function x_notifybar(title)
                         if (clientType == this.atom)
                         {
                             require('DescriptorEvents').removeDescriptor(fd);
-                            require('monitor-info')._X11.XCloseDisplay(this._display);
                             ret.emit('close');
-                            ret._windows.clear();
                             break;
                         }
                     }
@@ -654,7 +653,7 @@ function x_notifybar(title)
                 }
             });
         }
-       
+
     });
     return (ret);
 }
@@ -687,5 +686,3 @@ switch(process.platform)
         module.exports = macos_messagebox;
         break;
 }
-
-


### PR DESCRIPTION
Fix-#220-Notifybar-does-not-close-on-Linux-when-disconnected

- Call XDestroyWindow() in the close()-function of x_notifybar. This closes the notifybar, when the desktop connection is closed.
- Removed the XCloseDisplay() and _windows.clear() calls in the on( 'readset' ) function. The calls caused meshagent crashes, if  the notifybar is closed with the mouse, disconnected and then reconnected. They seem to be unnecessary. The notifybar is closed by the close() function.
-  Moved the setAlwaysOnTop() call down after the XMapWindow() call. The notifybar window must be mapped, otherwise the setAlwaysOnTop() call has no effect.