### PR TITLE
Force alignment of allocated memory to prevent segmentation faults on ARM systems

### DIFF
--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -1036,6 +1036,8 @@ void* ILibMemory_SmartReAllocate(void *ptr, size_t len)
 		size_t originalRawSize = ILibMemory_Init_Size(ILibMemory_Size(ptr), ILibMemory_ExtraSize(ptr));
 		size_t originalSize = ILibMemory_Size(ptr);
 		size_t originalExtraSize = ILibMemory_ExtraSize(ptr);
+		if (originalExtraSize)
+			len = (len + sizeof(void *) - 1) & -sizeof(void *);
 		size_t newRawSize = ILibMemory_Init_Size(len, originalExtraSize);
 
 		if (newRawSize < originalRawSize && originalExtraSize > 0)

--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -1095,6 +1095,7 @@ void* ILibMemory_SmartAllocateEx_ResizeExtra(void *ptr, size_t newExtraSize)
 void* ILibMemory_Init(void *ptr, size_t primarySize, size_t extraSize, ILibMemory_Types memType)
 {
 	if (ptr == NULL) { ILIBCRITICALEXIT(254); }
+	if (extraSize) primarySize = (primarySize + sizeof(void *) - 1) & -sizeof(void *);
 	memset(ptr, 0, primarySize + extraSize + sizeof(ILibMemory_Header) + (extraSize > 0 ? sizeof(ILibMemory_Header) : 0));
 
 	void *primary = ILibMemory_FromRaw(ptr);

--- a/microstack/ILibParsers.h
+++ b/microstack/ILibParsers.h
@@ -480,7 +480,7 @@ int ILibIsRunningOnChainThread(void* chain);
 	#define ILibMemory_FromRaw(ptr) ((char*)(ptr) + sizeof(ILibMemory_Header))
 
 	#define ILibMemory_Size_Validate(primaryLen, extraLen) (((size_t)(primaryLen)<(UINT32_MAX - (size_t)(extraLen)))&&((size_t)(extraLen)<(UINT32_MAX-(size_t)(primaryLen)))&&((size_t)((primaryLen) + (extraLen))<(UINT32_MAX - sizeof(ILibMemory_Header)))&&((extraLen)==0 || ((size_t)((primaryLen)+(extraLen)+sizeof(ILibMemory_Header))<(UINT32_MAX-sizeof(ILibMemory_Header)))))
-	#define ILibMemory_Init_Size(primaryLen, extraLen) (primaryLen + extraLen + sizeof(ILibMemory_Header) + (extraLen>0?sizeof(ILibMemory_Header):0))
+	#define ILibMemory_Init_Size(primaryLen, extraLen) (primaryLen + extraLen + sizeof(ILibMemory_Header) + (extraLen>0?sizeof(ILibMemory_Header) + (((primaryLen + sizeof(ILibMemory_Header)) + sizeof(void *) - 1) & - sizeof(void *)):0))
 	void* ILibMemory_Init(void *ptr, size_t primarySize, size_t extraSize, ILibMemory_Types memType);
 	#define ILibMemory_SmartAllocate(len) ILibMemory_InitEx(ILibMemory_Size_Validate(len,0)?malloc(ILibMemory_Init_Size(len, 0)):NULL, (int)len, 0, ILibMemory_Types_HEAP)
 	#define ILibMemory_SmartAllocateEx(primaryLen, extraLen) ILibMemory_InitEx(ILibMemory_Size_Validate(primaryLen,extraLen)?malloc(ILibMemory_Init_Size(primaryLen, extraLen)):NULL, (int)primaryLen, (int)extraLen, ILibMemory_Types_HEAP)


### PR DESCRIPTION
I fixed a minor nuisances that I encountered with the agent. Feel free to either pull outright, or edit and apply your own fix. This is  a one-liner.

I noticed when running the agent on my Raspberry Pi (which has a 32bit userspace and 64bit kernel for some random reason), it would always result in a segmentation fault. Turns out, dynamically allocated memory wasn't aligned properly. This isn't an issue on x86 systems, which supports unaligned memory accesses but proved to be a problem on ARM. My fix should address the observed issue, and it can't make things any worse as it only ever increases alignment, but it's a bit simplistic. A proper fix would need a lot more architecture-specific code. In practice, I am not sure that's actually needed, though. Most commonly used CPU architectures should be happy with aligning to a multiple of the natural pointer size.