### PR TITLE
Filter out X11 servers running inside containers to avoid showing bogus "Desktop" tab when X11 isn't available

### DIFF
--- a/modules/monitor-info.js
+++ b/modules/monitor-info.js
@@ -390,7 +390,7 @@ function monitorinfo()
                 }
                 else
                 {
-                    ch.stdin.write('ps -e | grep X\nexit\n');
+                    ch.stdin.write("ps -e -o comm,cgroup|egrep '^X.*(-|::/user.slice.*)$'\nexit\n");
                 }
                 ch.waitExit();
 


### PR DESCRIPTION
I fixed a minor nuisances that I encountered with the agent. Feel free to either pull outright, or edit and apply your own fix. This is a one-liner.

When installing the agent on my virtualization host, I was presented with a "Desktop" tab that never worked. This didn't make much sense, as the host is headless and doesn't even have an X11 server. We should never even see the "Desktop" tab on this system.

Turns out, the mesh agent erroneously detected a program running inside one of my containers and thought it might be an X11 server. Filtering by control group is an easy way to exclude these false positives.

A minor complication is that on modern Linux systems, control groups are used both by the containerization system (e.g. LXC) and for the management of user sessions. So, an X11 server running on the host could either be lacking a control group (if this was a really old system) or it could have a control group that starts with 0::/user.slice/... (if this is modern Linux system using control groups for session management). A regular expression allows us to catch these different options.

On the other hand, a process running inside a container would have something like 0::/lxc/XXXX/ns/ as its control group.