### PR TITLE
Feat/agent validate webcert

### DIFF
--- a/microscript/ILibDuktape_net.c
+++ b/microscript/ILibDuktape_net.c
@@ -2107,7 +2107,7 @@ int ILibDuktape_TLS_verify(int preverify_ok, X509_STORE_CTX *storectx)
 
 	duk_push_heapptr(data->ctx, data->object);												// [Socket]
 	duk_get_prop_string(data->ctx, -1, ILibDuktape_SOCKET2OPTIONS);							// [Socket][Options]
-	if (Duktape_GetBooleanProperty(data->ctx, -1, "rejectUnauthorized", 1)) { duk_pop_2(data->ctx); return(preverify_ok); }
+	if (Duktape_GetBooleanProperty(data->ctx, -1, "rejectUnauthorized", 1) && preverify_ok != 1) { duk_pop_2(data->ctx); return(preverify_ok); }
 	void *OnVerify = Duktape_GetHeapptrProperty(data->ctx, -1, "checkServerIdentity");
 	if (OnVerify == NULL) { duk_pop_2(data->ctx); return(1); }
 
@@ -2137,7 +2137,7 @@ int ILibDuktape_TLS_server_verify(int preverify_ok, X509_STORE_CTX *storectx)
 
 	duk_push_heapptr(data->ctx, data->self);													// [Server]
 	duk_get_prop_string(data->ctx, -1, ILibDuktape_SERVER2OPTIONS);								// [Server][Options]
-	if (Duktape_GetBooleanProperty(data->ctx, -1, "rejectUnauthorized", 1)) { duk_pop_2(data->ctx); return(preverify_ok); }
+	if (Duktape_GetBooleanProperty(data->ctx, -1, "rejectUnauthorized", 1) && preverify_ok != 1) { duk_pop_2(data->ctx); return(preverify_ok); }
 	void *OnVerify = Duktape_GetHeapptrProperty(data->ctx, -1, "checkClientIdentity");
 
 	if (OnVerify == NULL) { return(1); }

--- a/microscript/ILibDuktape_net.c
+++ b/microscript/ILibDuktape_net.c
@@ -2702,6 +2702,8 @@ duk_ret_t ILibDuktape_TLS_createSecureContext(duk_context *ctx)
 		SSL_CTX_use_PrivateKey(ssl_ctx, cert->pkey);
 	}
 
+	util_load_system_certs(ssl_ctx);
+
 	return(1);
 }
 duk_ret_t ILibDuktape_TLS_generateCertificate(duk_context *ctx)

--- a/microstack/ILibCrypto.h
+++ b/microstack/ILibCrypto.h
@@ -143,6 +143,7 @@ typedef enum CERTIFICATE_TYPES
 
 void  __fastcall util_openssl_init();
 void  __fastcall util_openssl_uninit();
+int  __fastcall util_load_system_certs(SSL_CTX *ctx);
 void  __fastcall util_free(char* ptr);
 
 // Certificate & crypto methods

--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -9405,14 +9405,14 @@ char* ILibString_Cat_s(char *destination, size_t destinationSize, char *source)
 {
 	size_t sourceLen = strnlen_s(source, destinationSize);
 	size_t i;
-	size_t *x = NULL;
+	size_t x = destinationSize;
 	for (i = 0; i < destinationSize - 1; ++i)
 	{
-		if (destination[i] == 0) { *x = i; break; }
+		if (destination[i] == 0) { x = i; break; }
 	}
-	if (x == NULL || ((*x + sourceLen + 1 )> destinationSize)) { ILIBCRITICALEXIT(254); }
-	memcpy_s(destination + *x, destinationSize - *x, source, sourceLen);
-	destination[*x + sourceLen] = 0;
+	if (((x + sourceLen + 1 )> destinationSize)) { ILIBCRITICALEXIT(254); }
+	memcpy_s(destination + x, destinationSize - x, source, sourceLen);
+	destination[x + sourceLen] = 0;
 	return(destination);
 }
 #ifndef WIN32

--- a/microstack/ILibWebClient.c
+++ b/microstack/ILibWebClient.c
@@ -3583,6 +3583,9 @@ int ILibWebClient_EnableHTTPS(ILibWebClient_RequestManager manager, struct util_
 			SSL_CTX_add_extra_chain_cert(ctx, X509_dup(nonLeafCert));
 		}
 	}
+	
+	util_load_system_certs(ctx);
+	
 	SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, ILibWebClient_Https_AuthenticateServer); // Ask for server authentication
 
 	if (ILibWebClientDataObjectIndex < 0)

--- a/microstack/ILibWebClient.c
+++ b/microstack/ILibWebClient.c
@@ -177,6 +177,7 @@ struct ILibWebClientManager
 	SSL_CTX *ssl_ctx;
 	ILibWebClient_OnSslConnection OnSslConnection;
 	ILibWebClient_OnHttpsConnection OnHttpsConnection;
+	void *OnHttpsConnectionData;
 	int EnableHTTPS_Called;
 	#endif
 
@@ -3541,7 +3542,7 @@ static int ILibWebClient_Https_AuthenticateServer(int preverify_ok, X509_STORE_C
 	if (wcdo->Parent->OnHttpsConnection != NULL)
 	{
 		STACK_OF(X509) *certChain = X509_STORE_CTX_get_chain(ctx);
-		retVal = wcdo->Parent->OnHttpsConnection(token, preverify_ok, certChain, &(wcdo->remote));
+		retVal = wcdo->Parent->OnHttpsConnection(token, preverify_ok, certChain, &(wcdo->remote), wcdo->Parent->OnHttpsConnectionData);
 		//sk_X509_free(certChain);
 	}
 	SSL_TRACE2("ILibWebClient_Https_AuthenticateServer()");
@@ -3554,7 +3555,7 @@ void ILibWebClient_SetTLS(ILibWebClient_RequestManager manager, void *ssl_ctx, I
 	wcm->ssl_ctx = (SSL_CTX*)ssl_ctx;
 	wcm->OnSslConnection = OnSslConnection;
 }
-int ILibWebClient_EnableHTTPS(ILibWebClient_RequestManager manager, struct util_cert* leafCert, X509* nonLeafCert, ILibWebClient_OnHttpsConnection OnHttpsConnection)
+int ILibWebClient_EnableHTTPS(ILibWebClient_RequestManager manager, struct util_cert* leafCert, X509* nonLeafCert, ILibWebClient_OnHttpsConnection OnHttpsConnection, void* OnHttpsConnectionData)
 {
 	SSL_CTX* ctx;
 	if (((struct ILibWebClientManager *)manager)->ssl_ctx != NULL) // SSL Context was already previously set
@@ -3595,6 +3596,7 @@ int ILibWebClient_EnableHTTPS(ILibWebClient_RequestManager manager, struct util_
 
 	((struct ILibWebClientManager *)manager)->ssl_ctx = ctx;
 	((struct ILibWebClientManager *)manager)->OnHttpsConnection = OnHttpsConnection;
+	((struct ILibWebClientManager *)manager)->OnHttpsConnectionData = OnHttpsConnectionData;
 	((struct ILibWebClientManager *)manager)->EnableHTTPS_Called = 1;
 	SSL_TRACE2("ILibWebClient_EnableHTTPS()");
 	return 0;

--- a/microstack/ILibWebClient.h
+++ b/microstack/ILibWebClient.h
@@ -145,7 +145,7 @@ typedef void(*ILibWebClient_OnDisconnect)(ILibWebClient_StateObject sender, ILib
 
 #ifndef MICROSTACK_NOTLS
 typedef int(*ILibWebClient_OnSslConnection)(ILibWebClient_StateObject sender, STACK_OF(X509) *certs, struct sockaddr_in6 *address, void *user);
-typedef int(*ILibWebClient_OnHttpsConnection)(ILibWebClient_RequestToken sender, int preverify_ok, STACK_OF(X509) *certs, struct sockaddr_in6 *address);
+typedef int(*ILibWebClient_OnHttpsConnection)(ILibWebClient_RequestToken sender, int preverify_ok, STACK_OF(X509) *certs, struct sockaddr_in6 *address, void *data);
 #endif
 
 //
@@ -273,7 +273,7 @@ typedef enum ILibWebClient_RequestToken_HTTPS
 
 #ifndef MICROSTACK_NOTLS
 void ILibWebClient_SetTLS(ILibWebClient_RequestManager manager, void *ssl_ctx, ILibWebClient_OnSslConnection OnSslConnection);
-int ILibWebClient_EnableHTTPS(ILibWebClient_RequestManager manager, struct util_cert* leafCert, X509* nonLeafCert, ILibWebClient_OnHttpsConnection OnHttpsConnection);
+int ILibWebClient_EnableHTTPS(ILibWebClient_RequestManager manager, struct util_cert* leafCert, X509* nonLeafCert, ILibWebClient_OnHttpsConnection OnHttpsConnection, void* OnHttpsConnectionData);
 void ILibWebClient_Request_SetHTTPS(ILibWebClient_RequestToken reqToken, ILibWebClient_RequestToken_HTTPS requestMode);
 void ILibWebClient_Request_SetSNI(ILibWebClient_RequestToken reqToken, char *host, int hostLen);
 #endif

--- a/microstack/ILibWebServer.c
+++ b/microstack/ILibWebServer.c
@@ -996,6 +996,7 @@ int ILibWebServer_EnableHTTPS(ILibWebServer_ServerToken object, struct util_cert
 
 	SSL_CTX_set_options(ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1);
 
+	util_load_system_certs(ctx);
 	SSL_CTX_use_certificate(ctx, leafCert->x509);
 	SSL_CTX_use_PrivateKey(ctx, leafCert->pkey);
 

--- a/microstack/ILibWrapperWebRTC.c
+++ b/microstack/ILibWrapperWebRTC.c
@@ -452,6 +452,7 @@ void ILibWrapper_WebRTC_InitializeCrypto(ILibWrapper_WebRTC_ConnectionFactoryStr
 		factory->ctx = SSL_CTX_new(DTLS_method());
 		//SSL_CTX_set_ecdh_auto(factory->ctx, 1); // Turn on elliptic curve for dTLS, this is required starting with Firefox 39. (DEPRECATED for OpenSSL/1.1.x)
 #endif
+		util_load_system_certs(factory->ctx);
 		if (ILibWrapper_WebRTC_ConnectionFactoryIndex < 0)
 		{
 			ILibWrapper_WebRTC_ConnectionFactoryIndex = SSL_CTX_get_ex_new_index(0, "ILibWrapper_WebRTC_ConnectionFactoryStruct index", NULL, NULL, NULL);

--- a/modules/RecoveryCore.js
+++ b/modules/RecoveryCore.js
@@ -153,7 +153,7 @@ require('MeshAgent').AddCommandHandler(function (data)
                             var xurl = getServerTargetUrlEx(data.value);
                             if (xurl != null) {
                                 var woptions = http.parseUri(xurl);
-                                woptions.rejectUnauthorized = 0;
+                                woptions.rejectUnauthorized = global._MSH && (global._MSH().validateWebCert === "true");
                                 //sendConsoleText(JSON.stringify(woptions));
                                 var tunnel = http.request(woptions);
                                 tunnel.on('upgrade', function (response, s, head)

--- a/modules/meshcmd.js
+++ b/modules/meshcmd.js
@@ -133,6 +133,7 @@ function run(argv) {
     if (args.nocommander) { settings.noconsole = true; }
     if (args.lmsdebug) { settings.lmsdebug = true; }
     if (args.tls) { settings.tls = true; }
+    if (args.validatewebcert) { settings.validatewebcert = true; }
     if ((argv.length > 1) && (actions.indexOf(argv[1].toUpperCase()) >= 0)) { settings.action = argv[1]; }
 
     // Validate meshaction.txt
@@ -623,7 +624,7 @@ function startMeshCommander() {
                 } else {
                     // If TLS is going to be used, setup a TLS socket
                     var tls = require('tls');
-                    var tlsoptions = { host: webargs.host, port: webargs.port, secureProtocol: ((webargs.tls1only == 1) ? 'TLSv1_method' : 'SSLv23_method'), rejectUnauthorized: false };
+                    var tlsoptions = { host: webargs.host, port: webargs.port, secureProtocol: ((webargs.tls1only == 1) ? 'TLSv1_method' : 'SSLv23_method'), rejectUnauthorized: settings.validatewebcert == true };
                     ws.forwardclient = tls.connect(tlsoptions, function () { this.pipe(this.ws, { end: false }); this.ws.pipe(this, { end: false }); });
                     ws.forwardclient.ws = ws;
                 }
@@ -1394,7 +1395,7 @@ function OnTcpClientConnected(c) {
             options = http.parseUri(settings.serverurl + '?user=' + settings.username + '&pass=' + settings.password + '&nodeid=' + settings.remotenodeid + '&tcpport=' + settings.remoteport);
         } catch (e) { console.log('Unable to parse \"serverUrl\".'); process.exit(1); return; }
         options.checkServerIdentity = onVerifyServer;
-        options.rejectUnauthorized = false;
+        options.rejectUnauthorized = settings.validatewebcert == true;
         c.websocket = http.request(options);
         c.websocket.tcp = c;
         c.websocket.tunneling = false;


### PR DESCRIPTION
Added an option to have the agent validate the webcert of the server to which it is connected. This is valuable in the case of a DNS hijack or MITM, which currently is possible if a bad actor can gain access to the meshcentral agent cert, and that cert can't be rotated or expired.

This is accomplished by adding `validateWebCert=true` in the msh file. It will continue to run as normal until such time as that value is set.

Once this is gone over, I will create a PR in the Meshcentral repo to update the meshcore and add a config option to have this option set on your agents by default.