### PR TITLE
fix: prevent double-free of controlChannelRequest on connection timeout

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -3777,6 +3777,10 @@ void MeshServer_ConnectEx_NetworkError(void *j)
 	MeshAgentHostContainer *agent = (MeshAgentHostContainer*)((void**)j)[0];
 	void *request = ((void**)j)[1];
 	ILibMemory_Free(j);
+	// Nullify immediately to prevent double-free: ILibWebClient_CancelRequest runs
+	// synchronously on the chain thread and triggers MeshServer_OnResponse, which would
+	// otherwise call ILibMemory_Free on this already-freed pointer a second time.
+	agent->controlChannelRequest = NULL;
 
 	if (agent->controlChannelDebug != 0) { ILIBLOGMESSAGEX("Network Timeout Occurred..."); }
 	agent->serverConnectionState = 0; // We are cancelling connection request


### PR DESCRIPTION
## Background

I'm not a C developer. I came across issue [Ylianst/MeshAgent#354](https://github.com/Ylianst/MeshAgent/issues/354) and the related issues [#110](https://github.com/Ylianst/MeshAgent/issues/110), [#151](https://github.com/Ylianst/MeshAgent/issues/151), and [#281](https://github.com/Ylianst/MeshAgent/issues/281) about the agent leaking memory during connection retries. I used GitHub Copilot to help me trace through the code and identify the root cause.

## Root Cause

In \meshcore/agentcore.c\, \MeshServer_ConnectEx_NetworkError\ frees the \j\ pointer (which is the same as \agent->controlChannelRequest\) but does **not** set \agent->controlChannelRequest = NULL\ afterward.

The issue is that \ILibWebClient_CancelRequest\ — called immediately after — executes **synchronously** on the chain thread (see the \ILibChain_RunOnMicrostackThread\ macro in \ILibParsers.h\):

```c
#define ILibChain_RunOnMicrostackThread(chain, handler, user) \
    if(ILibIsRunningOnChainThread(chain)==0){ \
        ILibChain_RunOnMicrostackThreadEx(chain, handler, user); \
    } else { \
        handler(chain,user);  // <-- synchronous when already on chain thread \
    }
```

This synchronous cancel internally calls \MeshServer_OnResponse\ with \ReceiveStatus_Complete\. That function checks \agent->controlChannelRequest != NULL\ and calls \ILibMemory_Free(agent->controlChannelRequest)\ — on a pointer that was **already freed** moments earlier. This is a **double-free**, which corrupts the heap allocator's internal state and causes memory usage to grow continuously with every retry cycle (~every 20 seconds when the server is unreachable).

## The Fix

One line added in \MeshServer_ConnectEx_NetworkError\, right after \ILibMemory_Free(j)\:

```
agent->controlChannelRequest = NULL;
```

This ensures \MeshServer_OnResponse\ safely skips the cleanup block (it checks for \!= NULL\ first), preventing the double-free.

## Caveats

- I have **not** been able to compile or test this change — I don't have the build environment set up.
- The logic analysis was done with AI assistance (GitHub Copilot). The reasoning is sound to the best of my understanding, but I'd strongly appreciate a review from someone familiar with the codebase before merging.
- I'm happy to update or close this PR if the analysis is wrong.