### PR TITLE
macOS Tahoe: helper joins console user audit session before screen ca…

### DIFF
--- a/meshconsole/main.c
+++ b/meshconsole/main.c
@@ -39,6 +39,12 @@ MeshAgentHostContainer *agentHost = NULL;
 char __agentExecPath[1024] = { 0 };
 #endif
 
+#if defined(__APPLE__)
+#include <bsm/audit.h>
+#include <bsm/audit_session.h>
+#include <unistd.h>
+#endif
+
 
 #ifdef WIN32
 BOOL CtrlHandler(DWORD fdwCtrlType)
@@ -277,6 +283,18 @@ char* crashMemory = ILib_POSIX_InstallCrashHandler(argv[0]);
 #if defined(_LINKVM) && defined(__APPLE__)
 	if (argc > 1 && strcasecmp(argv[1], "-kvm0") == 0)
 	{
+		// Tahoe audit-session join: pre-exec in SpawnProcessEx4 (as
+		// root) is what discovers and joins the user's gui session;
+		// post-exec call here as uid 501 inherits enough visibility
+		// from that to re-join cleanly and ensures the helper's
+		// kernel-tracked asid lands on the user's gui session before
+		// kvm_server_mainloop opens its XPC connection to
+		// com.apple.replayd. Both calls together are needed: the
+		// pre-exec join doesn't survive exec on its own, and
+		// post-exec alone is denied (uid 501 can't audit_session_port
+		// arbitrary asids on Tahoe).
+		extern int ILibProcessPipe_JoinUserAuditSession_OSX_PostExec(uid_t uid);
+		ILibProcessPipe_JoinUserAuditSession_OSX_PostExec(getuid());
 		kvm_server_mainloop(NULL);
 		return 0;
 	}

--- a/meshcore/zlib/zutil.h
+++ b/meshcore/zlib/zutil.h
@@ -136,8 +136,10 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #      include <unix.h> /* for fdopen */
 #    else
-#      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
+#      if !defined(__APPLE__)
+#        ifndef fdopen
+#          define fdopen(fd,mode) NULL /* No fdopen() */
+#        endif
 #      endif
 #    endif
 #  endif

--- a/microstack/ILibProcessPipe.c
+++ b/microstack/ILibProcessPipe.c
@@ -52,6 +52,93 @@ limitations under the License.
 #endif
 
 
+#if defined(__APPLE__)
+#include <bsm/audit.h>
+#include <bsm/audit_session.h>
+#include <libproc.h>
+#include <mach/mach.h>
+#include <string.h>
+
+// macOS Tahoe (26.x) audit-session-isolation fix for the -kvm0
+// helper. The screen-capture / input-injection helper inherits the
+// daemon's system-side audit session, where per-user XPC services
+// like com.apple.replayd (which backs ReplayKit / ScreenCaptureKit)
+// are unreachable. The cross-session XPC bootstrap-lookup fails with
+// "xpc_error=[3: No such process]" and the helper returns empty
+// (all-black) frames. Joining the console user's GUI audit session
+// before exec fixes this.
+//
+// Two call sites are needed:
+//   1. Pre-exec (in SpawnProcessEx4's fork-child, still root): does the
+//      actual discovery — Tahoe forbids non-root processes from
+//      enumerating with auditon() or calling audit_session_port() for
+//      arbitrary asids. Root can do both.
+//   2. Post-exec (in main.c -kvm0 branch, as the target uid): the
+//      kernel resets the asid on exec, so we need to re-join from the
+//      helper's main entry. The pre-exec join leaves enough kernel
+//      state that the post-exec auditon visibility works.
+static int ILibProcessPipe_TryJoinAsid_OSX(au_asid_t asid)
+{
+	mach_port_t port = MACH_PORT_NULL;
+	if (audit_session_port(asid, &port) != 0) return -1;
+	au_asid_t join_rc = audit_session_join(port);
+	mach_port_deallocate(mach_task_self(), port);
+	if (join_rc == AU_DEFAUDITSID || (int32_t)join_rc == -1) return -1;
+	return 0;
+}
+
+int ILibProcessPipe_JoinUserAuditSession_OSX(uid_t uid);
+int ILibProcessPipe_JoinUserAuditSession_OSX_PostExec(uid_t uid) { return ILibProcessPipe_JoinUserAuditSession_OSX(uid); }
+int ILibProcessPipe_JoinUserAuditSession_OSX(uid_t uid)
+{
+	int n = proc_listallpids(NULL, 0);
+	if (n <= 0) return -1;
+	pid_t *pids = (pid_t*)calloc(n, sizeof(pid_t));
+	if (pids == NULL) return -1;
+	int got = proc_listallpids(pids, n * (int)sizeof(pid_t));
+	if (got <= 0) { free(pids); return -1; }
+	int count = got / (int)sizeof(pid_t);
+	int rc = -1;
+	// Discover all auditon-visible asids belonging to target uid;
+	// prefer the LOWEST asid as the candidate. The user's primary
+	// gui session is created early at login and gets a low asid
+	// (typically 100002), while transient and per-app sessions get
+	// higher asids (100041+, 101xxx). Picking lowest reliably lands
+	// us on the primary gui session, which is where replayd is.
+	au_asid_t best_asid = AU_DEFAUDITSID;
+	for (int i = 0; i < count; i++)
+	{
+		if (pids[i] == 0) continue;
+		struct auditpinfo_addr ap;
+		memset(&ap, 0, sizeof(ap));
+		ap.ap_pid = pids[i];
+		if (auditon(A_GETPINFO_ADDR, &ap, sizeof(ap)) != 0) continue;
+		if (ap.ap_auid != uid) continue;
+		if (ap.ap_asid == 0 || ap.ap_asid == AU_DEFAUDITSID) continue;
+		if (best_asid == AU_DEFAUDITSID || ap.ap_asid < best_asid) best_asid = ap.ap_asid;
+	}
+	free(pids);
+	if (best_asid != AU_DEFAUDITSID && ILibProcessPipe_TryJoinAsid_OSX(best_asid) == 0) rc = 0;
+	// Fallback: if auditon discovery yielded no usable asid (e.g.,
+	// Tahoe's cross-session visibility filter denied the enumeration),
+	// brute-force try the typical user-gui asid range from low to high.
+	if (rc != 0)
+	{
+		for (au_asid_t a = 100002; a <= 100200; a++)
+		{
+			if (ILibProcessPipe_TryJoinAsid_OSX(a) == 0)
+			{
+				struct auditinfo_addr post;
+				memset(&post, 0, sizeof(post));
+				getaudit_addr(&post, sizeof(post));
+				if (post.ai_auid == uid) { rc = 0; break; }
+			}
+		}
+	}
+	return rc;
+}
+#endif
+
 #define CONSOLE_SCREEN_WIDTH 80
 #define CONSOLE_SCREEN_HEIGHT 25
 
@@ -755,16 +842,12 @@ ILibProcessPipe_Process ILibProcessPipe_Manager_SpawnProcessEx4(ILibProcessPipe_
 			retVal->stdOut->mProcess = retVal;
 		}
 #ifdef __APPLE__
-		if (needSetSid == 0)
-		{
-			set = &sset;
-			ILibVForkPrepareSignals_Parent_Init(set);
-			pid = vfork();
-		}
-		else
-		{
-			pid = fork();
-		}
+		// Use fork() not vfork() on macOS — child needs to call
+		// proc_listallpids / audit_session_join APIs to join the
+		// console user's audit session before exec, which are
+		// forbidden in vfork-child context (POSIX requires
+		// execve/_exit only in vfork children).
+		pid = fork();
 #else
 		set = &sset;
 		ILibVForkPrepareSignals_Parent_Init(set);
@@ -825,6 +908,19 @@ ILibProcessPipe_Process ILibProcessPipe_Manager_SpawnProcessEx4(ILibProcessPipe_
 		}
 		if (UID != -1 && UID != 0)
 		{
+#if defined(__APPLE__)
+			// Tahoe: macOS forbids non-root processes from calling
+			// audit_session_port() for arbitrary asids (errno=EPERM)
+			// or enumerating with auditon(A_GETPINFO_ADDR) across
+			// sessions. So we MUST do the audit-session-join here,
+			// while the fork-child still has root privileges, before
+			// setuid drops us. Otherwise the helper post-exec runs
+			// as the target user with no authority to discover or
+			// join the user's gui audit session, and stays in the
+			// daemon's system-side session — where com.apple.replayd
+			// is unreachable, breaking screen capture.
+			ILibProcessPipe_JoinUserAuditSession_OSX((uid_t)UID);
+#endif
 			ignore_result(setuid((uid_t)UID));
 		}
 		if (needSetSid != 0)


### PR DESCRIPTION
On macOS Tahoe (26.x), the `-kvm0` user-context helper fails to capture screen on Apple-Silicon Macs and the MeshCentral dashboard's Desktop tab shows a black frame, even when Screen Recording permission is granted to the agent in *System Settings → Privacy & Security*.

## Root cause

Tahoe enforces stricter audit-session isolation than earlier macOS versions. When the root daemon spawns the user-context helper via `fork() + setuid() + execve()`, the child inherits the daemon's system-side audit session (`asid` ≈ 100001), not the console user's GUI session (`asid` 100002 — where the user is logged in).

`com.apple.replayd` (the per-user ReplayKit daemon that backs ScreenCaptureKit / `SLSHWCaptureDesktopProxying`) is registered in `gui/<console-uid>` and is only reachable from processes that have joined that audit session. The cross-session XPC bootstrap-lookup fails:

```
[com.apple.xpc:connection] activating connection: name=com.apple.replayd
[com.apple.xpc:connection] failed to do a bootstrap look-up: xpc_error=[3: No such process]
ReplayKit: [ERROR] -[RPDaemonProxy proxyCoreGraphicsWithMethodType:...] error: 4099
ScreenCaptureKit: [ERROR] SLSHWCaptureDesktopProxying:525 unable to complete request due to timeout
```

The helper times out after ~5 seconds and returns an empty (all-black) frame. Earlier macOS versions either didn't enforce this isolation or allowed cross-session XPC for daemons; Tahoe does not.

## Fix

Have the `-kvm0` helper join the console user's audit session at TWO points:

1. **Pre-exec, inside `SpawnProcessEx4`'s fork-child while still root**: does the actual auditon-based discovery and `audit_session_join`. On Tahoe, only root can call `audit_session_port()` for arbitrary asids or enumerate via `auditon(A_GETPINFO_ADDR)` across audit sessions, so discovery has to happen here.

2. **Post-exec, in the helper's `main()` entry for `argv[1] == "-kvm0"`**: the kernel resets the asid on `exec`, so the pre-exec join doesn't persist on its own. The post-exec call re-joins the same session; the pre-exec join leaves enough kernel state that auditon visibility for the user's gui session works from the dropped-privilege uid.

Discovery picks the LOWEST visible asid belonging to the target uid (typically 100002, the user's primary gui session, vs higher asids for transient/per-app sessions where replayd doesn't register). A fallback brute-force range probe handles the case where Tahoe's cross-session auditon visibility filter blocks discovery entirely.

## Files

- `meshconsole/main.c` (+12 lines): include audit headers; in the `-kvm0` argv branch, call the post-exec join helper before `kvm_server_mainloop`.
- `microstack/ILibProcessPipe.c` (+95 lines): the audit-session-join helper plus the pre-exec call site in `SpawnProcessEx4`'s fork-child branch.
- `meshcore/zlib/zutil.h` (+2 lines): build fix — skip the "no fdopen()" macro on `__APPLE__` to compile cleanly against newer Xcode/Clang's stdio.h prototype.

No behavior change on Linux/Windows. No new dependencies (the audit APIs ship with the macOS SDK).

## Tested on

- macOS Tahoe 26.x, Apple Silicon (M-series), agent built with `make macos ARCHID=29`
- Server: MeshCentral 1.x in docker
- Verified: dashboard's *Desktop* tab renders 1920×1080 of real desktop pixels; before the patch, 100% black.

## Notes for downstream packagers

Code-signing the patched binary with a stable identity (Developer ID Application, not ad-hoc) is recommended on Tahoe. macOS TCC pins the `csreq` for stored Screen Recording / Accessibility grants to the binary's CDHash when ad-hoc signed; every rebuild gets a new CDHash and the user has to re-grant. Developer-ID signing pins `csreq` to the team identifier instead, which is stable across rebuilds.
