### PR TITLE
Run Duktape GC after system proxy detection

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -418,6 +418,8 @@ int MeshAgent_GetSystemProxy(MeshAgentHostContainer *agent, char *inBuffer, size
 		}
 	}
 	duk_pop(agent->meshCoreCtx);															// ...
+	// Proxy detection can create short-lived EventEmitter/ChildProcess object graphs. Run GC here so repeated reconnects do not retain them until a later heap cycle.
+	duk_gc(agent->meshCoreCtx, 0);
 	return((int)bufferLen);
 }
 #ifdef _POSIX


### PR DESCRIPTION
## Summary

This PR fixes the growing Duktape heap usage observed in relation to
Ylianst/MeshAgent#354.

During repeated reconnect attempts, `MeshAgent_GetSystemProxy()` can
execute the `proxy-helper` JavaScript path many times. Without an explicit GC
pass after proxy detection, temporary JavaScript objects can remain retained
until a later heap cycle. In long-running reconnect scenarios this caused peak
heap usage to grow significantly over time.

This change runs a Duktape GC pass immediately after the proxy-helper result is
read and popped from the Duktape stack.

## Debugging / Investigation

The issue was investigated with `heaptrack` on Linux while forcing repeated
reconnect attempts.

The original run showed `MeshAgent_GetSystemProxy()` / `proxy-helper` as the
dominant Duktape allocation path:

- Runtime: ~8772 seconds
- Peak heap: ~105 MB (growing)
- Peak RSS: ~176 MB

As a diagnostic step, system proxy detection was temporarily bypassed. With that
path disabled, peak heap usage stayed around 10 MB, confirming that repeated
system proxy detection was the driver of the heap growth.

After adding the explicit Duktape GC after proxy detection, the same reconnect
scenario stayed stable:

- Runtime: ~25278 seconds
- Reconnect cycles: ~1219
- Peak heap: ~10 MB (stable)
- Peak RSS: ~110 MB

## Validation

Tested on 2 Linux systems (Debian 12 and Ubuntu 26.04) with `heaptrack`.

The long patched run stayed around 10 MB peak heap after roughly 7 hours and
more than 1200 reconnect cycles.

I could not reproduce the issue in a controlled way on Windows, but this should
also help there because the fix is applied at the common
`MeshAgent_GetSystemProxy()` call site. It compiles and runs fine with VS2022. Tested on Windows 10/11 64bit.

## Note

AI assistance was used to help analyze the heaptrack reports and review the
relevant source code paths. The patch itself was validated with manual Linux
heaptrack runs as described above.
