### PR TITLE
Minimize memory leaks when server is unreachable

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4266,6 +4266,39 @@ void MeshServer_Agent_SelfTest(MeshAgentHostContainer *agent)
 	duk_pop(agent->meshCoreCtx);
 }
 
+#ifdef WIN32
+static void MeshServer_CheckAuthenticode(MeshAgentHostContainer *agent)
+{
+	if (agent->authenticodeChecked != 0) return;
+
+	duk_idx_t top = duk_get_top(agent->meshCoreCtx);
+	if (duk_peval_string(agent->meshCoreCtx, "require('win-authenticode-opus')(process.execPath);") == 0)							// [obj]
+	{
+		if (!duk_is_null_or_undefined(agent->meshCoreCtx, -1))
+		{
+			char *url = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "url", NULL);
+			if (url != NULL)
+			{
+				duk_push_sprintf(agent->meshCoreCtx, "require('win-authenticode-opus').locked('%s');", url);						// [obj][str]
+				if (duk_peval(agent->meshCoreCtx) == 0 && !duk_is_null_or_undefined(agent->meshCoreCtx, -1))						// [obj][obj]
+				{
+					char *dns = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "dns", NULL);
+					char *id = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "id", NULL);
+					if (dns != NULL && id != NULL)
+					{
+						strcpy_s(agent->DNS_LOCK, sizeof(agent->DNS_LOCK), dns);
+						strcpy_s(agent->ID_LOCK, sizeof(agent->ID_LOCK), id);
+					}
+				}
+			}
+		}
+	}
+	duk_set_top(agent->meshCoreCtx, top);																							// ...
+	duk_gc(agent->meshCoreCtx, 0);
+	agent->authenticodeChecked = 1;
+}
+#endif
+
 void MeshServer_Connect(MeshAgentHostContainer *agent)
 {
 	unsigned int timeout;
@@ -4280,34 +4313,7 @@ void MeshServer_Connect(MeshAgentHostContainer *agent)
 	}
 
 #ifdef WIN32
-	if (agent->authenticodeChecked == 0)
-	{
-		duk_idx_t top = duk_get_top(agent->meshCoreCtx);
-		if (duk_peval_string(agent->meshCoreCtx, "require('win-authenticode-opus')(process.execPath);") == 0)							// [obj]
-		{
-			if (!duk_is_null_or_undefined(agent->meshCoreCtx, -1))
-			{
-				char *url = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "url", NULL);
-				if (url != NULL)
-				{
-					duk_push_sprintf(agent->meshCoreCtx, "require('win-authenticode-opus').locked('%s');", url);						// [obj][str]
-					if (duk_peval(agent->meshCoreCtx) == 0 && !duk_is_null_or_undefined(agent->meshCoreCtx, -1))						// [obj][obj]
-					{
-						char *dns = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "dns", NULL);
-						char *id = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "id", NULL);
-						if (dns != NULL && id != NULL)
-						{
-							strcpy_s(agent->DNS_LOCK, sizeof(agent->DNS_LOCK), dns);
-							strcpy_s(agent->ID_LOCK, sizeof(agent->ID_LOCK), id);
-						}
-					}
-				}
-			}
-		}
-		duk_set_top(agent->meshCoreCtx, top);																							// ...
-		duk_gc(agent->meshCoreCtx, 0);
-		agent->authenticodeChecked = 1;
-	}
+	MeshServer_CheckAuthenticode(agent);
 #endif
 
 	util_random(sizeof(int), (char*)&timeout);

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4302,7 +4302,8 @@ void MeshServer_Connect(MeshAgentHostContainer *agent)
 			}
 		}
 	}
-	duk_set_top(agent->meshCoreCtx, top);																							// ...
+	duk_set_top(agent->meshCoreCtx, top);		
+	duk_gc(agent->meshCoreCtx, 0);																					// ...
 #endif
 
 	util_random(sizeof(int), (char*)&timeout);

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4026,6 +4026,7 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 		{
 			printf("agentcore: DNS Lock[%s]: Unauthorized to connect to: %s\n", agent->DNS_LOCK, host);
 			free(host); free(path);
+			ILibDestructParserResults(rs);
 			ILibLifeTime_Add(ILibGetBaseTimer(agent->chain), agent, 5, MeshServer_ConnectEx_Lockout_Retry, NULL);
 			return;
 		}
@@ -4103,6 +4104,7 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 		{
 			printf("agentcore: ServerID Lock: ServerID MISMATCH for: %s\n", host);
 			free(host); free(path);
+			ILibDestructParserResults(rs);
 			ILibLifeTime_Add(ILibGetBaseTimer(agent->chain), agent, 5, MeshServer_ConnectEx_Lockout_Retry, NULL);
 			return;
 		}

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -3552,7 +3552,6 @@ void MeshServer_OnResponse(ILibWebClient_StateObject WebStateObject, int Interru
 	if (agent->controlChannelRequest != NULL)
 	{
 		ILibLifeTime_Remove(ILibGetBaseTimer(agent->chain), agent->controlChannelRequest);
-		ILibMemory_Free(agent->controlChannelRequest);
 		agent->controlChannelRequest = NULL;
 	}
 

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4280,30 +4280,34 @@ void MeshServer_Connect(MeshAgentHostContainer *agent)
 	}
 
 #ifdef WIN32
-	duk_idx_t top = duk_get_top(agent->meshCoreCtx);
-	if (duk_peval_string(agent->meshCoreCtx, "require('win-authenticode-opus')(process.execPath);") == 0)							// [obj]
+	if (agent->authenticodeChecked == 0)
 	{
-		if (!duk_is_null_or_undefined(agent->meshCoreCtx, -1))
+		duk_idx_t top = duk_get_top(agent->meshCoreCtx);
+		if (duk_peval_string(agent->meshCoreCtx, "require('win-authenticode-opus')(process.execPath);") == 0)							// [obj]
 		{
-			char *url = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "url", NULL);
-			if (url != NULL)
+			if (!duk_is_null_or_undefined(agent->meshCoreCtx, -1))
 			{
-				duk_push_sprintf(agent->meshCoreCtx, "require('win-authenticode-opus').locked('%s');", url);						// [obj][str]
-				if (duk_peval(agent->meshCoreCtx) == 0 && !duk_is_null_or_undefined(agent->meshCoreCtx, -1))						// [obj][obj]
+				char *url = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "url", NULL);
+				if (url != NULL)
 				{
-					char *dns = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "dns", NULL);
-					char *id = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "id", NULL);
-					if (dns != NULL && id != NULL)
+					duk_push_sprintf(agent->meshCoreCtx, "require('win-authenticode-opus').locked('%s');", url);						// [obj][str]
+					if (duk_peval(agent->meshCoreCtx) == 0 && !duk_is_null_or_undefined(agent->meshCoreCtx, -1))						// [obj][obj]
 					{
-						strcpy_s(agent->DNS_LOCK, sizeof(agent->DNS_LOCK), dns);
-						strcpy_s(agent->ID_LOCK, sizeof(agent->ID_LOCK), id);
+						char *dns = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "dns", NULL);
+						char *id = Duktape_GetStringPropertyValue(agent->meshCoreCtx, -1, "id", NULL);
+						if (dns != NULL && id != NULL)
+						{
+							strcpy_s(agent->DNS_LOCK, sizeof(agent->DNS_LOCK), dns);
+							strcpy_s(agent->ID_LOCK, sizeof(agent->ID_LOCK), id);
+						}
 					}
 				}
 			}
 		}
+		duk_set_top(agent->meshCoreCtx, top);																							// ...
+		duk_gc(agent->meshCoreCtx, 0);
+		agent->authenticodeChecked = 1;
 	}
-	duk_set_top(agent->meshCoreCtx, top);		
-	duk_gc(agent->meshCoreCtx, 0);																					// ...
 #endif
 
 	util_random(sizeof(int), (char*)&timeout);
@@ -4529,6 +4533,7 @@ MeshAgentHostContainer* MeshAgent_Create(MeshCommand_AuthInfo_CapabilitiesMask c
 			retVal->shCore = NULL;
 		}
 	}
+	retVal->authenticodeChecked = 0;
 #endif
 
 	retVal->agentID = (AgentIdentifiers)MESH_AGENTID;

--- a/meshcore/agentcore.h
+++ b/meshcore/agentcore.h
@@ -187,6 +187,7 @@ typedef struct MeshAgentHostContainer
 	DpiAwarenessFunc dpiAwareness;
 	char DNS_LOCK[255];
 	char ID_LOCK[255];
+	int authenticodeChecked;
 #endif
 
 	int showModuleNames;

--- a/modules/win-authenticode-opus.js
+++ b/modules/win-authenticode-opus.js
@@ -33,6 +33,8 @@ function read(path)
     crypt.CreateMethod('CryptQueryObject');
     crypt.CreateMethod('CryptMsgGetParam');
     crypt.CreateMethod('CryptDecodeObject');
+    crypt.CreateMethod('CertCloseStore');
+    crypt.CreateMethod('CryptMsgClose');
 
     var dwEncoding = GM.CreateVariable(4);
     var dwContentType = GM.CreateVariable(4);
@@ -40,7 +42,7 @@ function read(path)
     var hStore = GM.CreatePointer();
     var hMsg = GM.CreatePointer();
     var dwSignerInfo = GM.CreateVariable(4);
-    var n, result;
+    var n, result = null;
 
     if (crypt.CryptQueryObject(CERT_QUERY_OBJECT_FILE, GM.CreateVariable(path, { wide: true }),
                     CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
@@ -87,15 +89,19 @@ function read(path)
                         var opus = GM.CreateVariable(dwData.toBuffer().readUInt32LE());
                         if (crypt.CryptDecodeObject(ENCODING, GM.CreateVariable(SPC_SP_OPUS_INFO_OBJID), pb, cb, 0, opus, dwData).Val != 0)
                         {
-                       
-                            return ({ description: opus.Deref().Val != 0 ? opus.Deref().Wide2UTF8 : null, url: opus.Deref(GM.PointerSize, GM.PointerSize).Deref().Val != 0 ? opus.Deref(GM.PointerSize, GM.PointerSize).Deref().Deref(GM.PointerSize, GM.PointerSize).Deref().Wide2UTF8.trim() : null });
+                            result = { description: opus.Deref().Val != 0 ? opus.Deref().Wide2UTF8 : null, url: opus.Deref(GM.PointerSize, GM.PointerSize).Deref().Val != 0 ? opus.Deref(GM.PointerSize, GM.PointerSize).Deref().Deref(GM.PointerSize, GM.PointerSize).Deref().Wide2UTF8.trim() : null };
                         }
                     }
+                    break;
                 }
             }
         }
     }
-    return (null);
+
+    if (hMsg.Deref().Val != 0) { crypt.CryptMsgClose(hMsg.Deref()); }
+    if (hStore.Deref().Val != 0) { crypt.CertCloseStore(hStore.Deref(), 0); }
+
+    return (result);
 }
 function locked(uri)
 {


### PR DESCRIPTION
This PR is related to https://github.com/Ylianst/MeshAgent/issues/110 and is a best effort to clear some memory leaks.

Recently in our project we've also noticed high memory usage in cases where the server is unreachable. I did small review of the reconnection loop and implemented a couple of fixes and optimizations.

I did some tests for which I dodged the exponential backoff mechanism and forced the reconnections every 10ms. I noticed that even after a couple of hours the memory footprint is relatively low and much lower that when I tested the code from `master` to establish a baseline. There could be some more memory leaks lurking there, though.

Quick summary of changes (details are in separate commits):
1. Closing some dangling handles
2. Add clean-up code in some early-exit paths
3. Removed one redundant call to ILibMemory_Free 
4. One additional, explicit invokation of `duk_gc`
5. Probably the biggest win: cache of the authenticode check result - I assumed that the binary itself will never be modified while running, so we can cache the check result. My guess is that some code in the `duk_*` functions which is now extracted to `MeshServer_CheckAuthenticode` was leaking memory.

Hope this helps.