### PR TITLE
Add logRotate and logTruncate options for the agent log

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4911,6 +4911,24 @@ int MeshAgent_AgentMode(MeshAgentHostContainer *agentHost, int paramLen, char **
 		}
 	}
 
+	if (ILibSimpleDataStore_Get(agentHost->masterDb, "logRotate", NULL, 0) != 0)
+	{
+		int len = ILibSimpleDataStore_Get(agentHost->masterDb, "logRotate", ILibScratchPad, sizeof(ILibScratchPad));
+		if (len < sizeof(ILibScratchPad))
+		{
+			uint64_t val = 0;
+			if (ILib_atoi_uint64(&val, ILibScratchPad, len) == 0 && val > 0)
+			{
+				ILibCriticalLog_CapMode = ILibAppendStringToDisk_Cap_Rotate;
+				ILibCriticalLog_RotateCount = (int)val; // value doubles as how many rotated logs to keep
+			}
+		}
+	}
+	if (ILibCriticalLog_CapMode == ILibAppendStringToDisk_Cap_Stop && ILibSimpleDataStore_Get(agentHost->masterDb, "logTruncate", NULL, 0) != 0)
+	{
+		ILibCriticalLog_CapMode = ILibAppendStringToDisk_Cap_Truncate;
+	}
+
 #ifdef WIN32
 	if (agentHost->noCertStore == 0) { agentHost->noCertStore = ILibSimpleDataStore_Get(agentHost->masterDb, "nocertstore", NULL, 0); }
 #endif

--- a/meshcore/agentcore.h
+++ b/meshcore/agentcore.h
@@ -289,8 +289,10 @@ fakeUpdate:					If set, when the agent self-updates, it will update to the same 
 forceUpdate:				If set, will cause the agent to perform a self-update on next start.
 ignoreProxyFile:			If set, will cause the agent to ignore any proxy settings
 logUpdate:					If set, will cause the agent to log self-update status
+logRotate:					If set to N>0, rotates the log file at maxLogSize, keeping N older copies (meshagent.log.1..N)
+logTruncate:				If set, clears and continues the log at maxLogSize instead of stopping. Ignored if logRotate is set
 jsDebugPort:				Specify a JS Debugger Port
-maxLogSize:					Specifies the maximum size of the error log file. 
+maxLogSize:					Maximum size in bytes of the log file (default 524288). When reached, logging stops unless logRotate/logTruncate is set.
 nocertstore:				If set on Windows, will force the Agent to use OpenSSL instead of WinCrypto for cert generation/storage.
 readonly:					If set, forces the agent to open the database in readonly mode
 readmsh:					If set while db is in readonly mode, it will cache the local msh file in the readonly db

--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -9646,6 +9646,109 @@ void ILibAppendStringToDiskEx2(char *FileName, char *data, int dataLen, uint64_t
 		fclose(SourceFile);
 	}
 }
+static int ILibRenameFileOnDisk(char *source, char *destination)
+{
+#ifdef WIN32
+	WCHAR SourceW[4096];
+	WCHAR DestW[4096];
+	ILibUTF8ToWideEx(source, -1, SourceW, (int)sizeof(SourceW) / 2);
+	ILibUTF8ToWideEx(destination, -1, DestW, (int)sizeof(DestW) / 2);
+	DeleteFileW(DestW); // MoveFileW fails if the destination already exists; POSIX rename() replaces it
+	return(MoveFileW(SourceW, DestW) ? 0 : 1);
+#else
+	return(rename(source, destination));
+#endif
+}
+void ILibAppendStringToDiskEx3(char *FileName, char *data, int dataLen, uint64_t maxSize, int capMode, int maxCount)
+{
+	FILE *SourceFile = NULL;
+	uint64_t curSize;
+
+	if (maxSize == 0) { ILibAppendStringToDiskEx2(FileName, data, dataLen, 0); return; } // 0 == unbounded, no cap policy to apply
+
+#ifdef WIN32
+	_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"ab");
+#else
+	SourceFile = fopen(FileName, "ab");
+#endif
+	if (SourceFile == NULL) { return; }
+
+	fseek(SourceFile, 0, SEEK_END);
+#ifdef WIN32
+	curSize = (uint64_t)_ftelli64(SourceFile);
+#else
+	curSize = (uint64_t)ftell(SourceFile);
+#endif
+
+	if (curSize < maxSize)
+	{
+		if (fwrite(data, sizeof(char), dataLen, SourceFile)) {}
+		if (capMode == ILibAppendStringToDisk_Cap_Stop)
+		{
+			// Stop mode goes silent once capped; leave a one-time marker on the entry that crosses the limit.
+			fseek(SourceFile, 0, SEEK_END);
+#ifdef WIN32
+			if ((uint64_t)_ftelli64(SourceFile) >= maxSize)
+#else
+			if ((uint64_t)ftell(SourceFile) >= maxSize)
+#endif
+			{
+				char *capMsg = "\r\n[log size limit reached - logging suspended until the file is rotated or removed]";
+				if (fwrite(capMsg, sizeof(char), (int)strnlen_s(capMsg, 128), SourceFile)) {}
+			}
+		}
+		fclose(SourceFile);
+		return;
+	}
+
+	if (capMode == ILibAppendStringToDisk_Cap_Truncate)
+	{
+		fclose(SourceFile);
+#ifdef WIN32
+		_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"wb");
+#else
+		SourceFile = fopen(FileName, "wb");
+#endif
+		if (SourceFile != NULL)
+		{
+			if (fwrite(data, sizeof(char), dataLen, SourceFile)) {}
+			fclose(SourceFile);
+		}
+	}
+	else if (capMode == ILibAppendStringToDisk_Cap_Rotate)
+	{
+		int i;
+		char rotateFrom[4096];
+		char rotateTo[4096];
+		fclose(SourceFile);
+		if (maxCount < 1) { maxCount = 1; }
+
+		// Shift .1 .. .(maxCount-1) up one (oldest .maxCount is overwritten), then current file becomes .1
+		for (i = maxCount - 1; i >= 1; --i)
+		{
+			sprintf_s(rotateFrom, sizeof(rotateFrom), "%s.%d", FileName, i);
+			sprintf_s(rotateTo, sizeof(rotateTo), "%s.%d", FileName, i + 1);
+			ILibRenameFileOnDisk(rotateFrom, rotateTo);
+		}
+		sprintf_s(rotateTo, sizeof(rotateTo), "%s.1", FileName);
+		ILibRenameFileOnDisk(FileName, rotateTo);
+
+#ifdef WIN32
+		_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"ab");
+#else
+		SourceFile = fopen(FileName, "ab");
+#endif
+		if (SourceFile != NULL)
+		{
+			if (fwrite(data, sizeof(char), dataLen, SourceFile)) {}
+			fclose(SourceFile);
+		}
+	}
+	else
+	{
+		fclose(SourceFile);
+	}
+}
 void ILibDeleteFileFromDisk(char *FileName)
 {
 #if defined(WIN32) || defined(_WIN32_WCE)
@@ -10959,6 +11062,8 @@ void ILib6to4(struct sockaddr* addr)
 // Log a critical error to file
 char ILibCriticalLogBuffer[sizeof(ILibScratchPad)];
 uint64_t ILibCriticalLog_MaxSize = ILIBCRITICALLOG_DEFAULT_MAXSIZE;
+int ILibCriticalLog_CapMode = ILibAppendStringToDisk_Cap_Stop;
+int ILibCriticalLog_RotateCount = 1;
 
 char* ILibCriticalLog (const char* msg, const char* file, int line, int user1, int user2)
 {
@@ -10972,7 +11077,7 @@ char* ILibCriticalLog (const char* msg, const char* file, int line, int user1, i
 	{
 		len = sprintf_s(ILibCriticalLogBuffer, sizeof(ILibCriticalLogBuffer), "\r\n[%s] [%s] %s", timeStamp, g_ILibCrashID_HASH != NULL ? g_ILibCrashID_HASH : "", msg);
 	}
-	if (len > 0 && len < (int)sizeof(ILibCriticalLogBuffer) && ILibCriticalLogFilename != NULL) ILibAppendStringToDiskEx2(ILibCriticalLogFilename, ILibCriticalLogBuffer, len, ILibCriticalLog_MaxSize);
+	if (len > 0 && len < (int)sizeof(ILibCriticalLogBuffer) && ILibCriticalLogFilename != NULL) ILibAppendStringToDiskEx3(ILibCriticalLogFilename, ILibCriticalLogBuffer, len, ILibCriticalLog_MaxSize, ILibCriticalLog_CapMode, ILibCriticalLog_RotateCount);
 	if (file != NULL)
 	{
 		ILibRemoteLogging_printf(ILibChainGetLogger(gILibChain), ILibRemoteLogging_Modules_Microstack_Generic, ILibRemoteLogging_Flags_VerbosityLevel_1, "%s:%d (%d,%d) %s", file, line, user1, user2, msg);

--- a/microstack/ILibParsers.h
+++ b/microstack/ILibParsers.h
@@ -936,6 +936,10 @@ int ILibIsRunningOnChainThread(void* chain);
 	void ILibWriteStringToDisk(char *FileName, char *data);
 	void ILibAppendStringToDiskEx2(char *FileName, char *data, int dataLen, uint64_t maxSize);
 	void ILibWriteStringToDiskEx(char *FileName, char *data, int dataLen);
+	#define ILibAppendStringToDisk_Cap_Stop		0
+	#define ILibAppendStringToDisk_Cap_Truncate	1
+	#define ILibAppendStringToDisk_Cap_Rotate	2
+	void ILibAppendStringToDiskEx3(char *FileName, char *data, int dataLen, uint64_t maxSize, int capMode, int maxCount);
 	void ILibDeleteFileFromDisk(char *FileName);
 	void ILibGetDiskFreeSpace(void *i64FreeBytesToCaller, void *i64TotalBytes);
 	int ILibFile_CopyTo(char *source, char *destination);
@@ -1603,6 +1607,8 @@ int ILibIsRunningOnChainThread(void* chain);
 
 #define ILIBCRITICALLOG_DEFAULT_MAXSIZE 524288
 	extern uint64_t ILibCriticalLog_MaxSize;
+	extern int ILibCriticalLog_CapMode;
+	extern int ILibCriticalLog_RotateCount;
 #define ILIBCRITICALEXITMSG(code, msg) {printf("%s", ILibCriticalLog(msg, __FILE__, __LINE__, 0, 0)); exit(code);}
 #define ILIBLOGMESSSAGE(msg) ILibCriticalLog(msg, __FILE__, __LINE__, 0, 0)
 	void ILIBLOGMESSAGEX(char *format, ...);

--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,10 @@ Here is a list of the possible keys that are currently supported by the agent. N
 | `forceUpdate` | If set, causes the agent to perform a self-update on next start. |
 | `ignoreProxyFile` | If set, causes the agent to ignore any proxy settings. |
 | `logUpdate` | If set, causes the agent to log self-update status. |
+| `logRotate` | If set to N (greater than 0), rotates the log file when it reaches `maxLogSize`, keeping N older copies (`meshagent.log.1` … `meshagent.log.N`). |
+| `logTruncate` | If set, clears the log file and continues when it reaches `maxLogSize` instead of stopping. Ignored if `logRotate` is set. |
 | `jsDebugPort` | Specifies a JS debugger port. |
-| `maxLogSize` | Maximum size of the error log file. |
+| `maxLogSize` | Maximum size in bytes of the log file (`meshagent.log`). Default 524288 (512 KiB). When reached, logging stops by default unless `logRotate` or `logTruncate` is set. |
 | `nocertstore` | Windows only. Forces the agent to use OpenSSL instead of WinCrypto for cert generation/storage. |
 | `readonly` | If set, forces the agent to open the database in read-only mode. |
 | `readmsh` | If set while db is in read-only mode, caches the local `.msh` file in the read-only db. |


### PR DESCRIPTION
Fixes #357.

maxLogSize caps the agent log, but once the cap was reached logging just stopped with no indication and didn't resume until the file was removed. It now just leaves one marker line when its triggered and there are two opt-in alternatives set in the .msh:

- logTruncate=1 - clear the log and keep writing
- logRotate=N - rotate to meshagent.log.1 .. .N and start a fresh file

If both are set, logRotate wins; its value is how many old copies to keep.

readme.md and the supported-key list in agentcore.h are updated to match.

**Disclaimer: an AI code assistant was using during the coding of this**