### PR TITLE
Fix GCing of pending setTimeout/setInterval timers

### DIFF
--- a/microscript/ILibDuktape_Polyfills.c
+++ b/microscript/ILibDuktape_Polyfills.c
@@ -1183,12 +1183,10 @@ void ILibDuktape_Polyfills_timer_elapsed(void *obj)
 	}
 	else
 	{
-		if (ptrs->timerType == ILibDuktape_Timer_Type_IMMEDIATE)
-		{
-			duk_push_heap_stash(ctx);
-			duk_del_prop_string(ctx, -1, Duktape_GetStashKey(ptrs->object));
-			duk_pop(ctx);
-		}
+		// setTimeout/setImmediate: release reference now it has fired.
+		duk_push_heap_stash(ctx);
+		duk_del_prop_string(ctx, -1, Duktape_GetStashKey(ptrs->object));
+		duk_pop(ctx);
 
 		duk_del_prop_string(ctx, -2, "\xFF_callback");
 		duk_del_prop_string(ctx, -2, "\xFF_argArray");
@@ -1236,11 +1234,6 @@ duk_ret_t ILibDuktape_Polyfills_timer_set(duk_context *ctx)
 	case ILibDuktape_Timer_Type_IMMEDIATE:
 		ILibDuktape_WriteID(ctx, "Timers.immediate");	
 		metadata = "setImmediate()";
-		// We're only saving a reference for immediates
-		duk_push_heap_stash(ctx);															//[retVal][stash]
-		duk_dup(ctx, -2);																	//[retVal][stash][immediate]
-		duk_put_prop_string(ctx, -2, Duktape_GetStashKey(duk_get_heapptr(ctx, -1)));		//[retVal][stash]
-		duk_pop(ctx);																		//[retVal]
 		break;
 	case ILibDuktape_Timer_Type_INTERVAL:
 		ILibDuktape_WriteID(ctx, "Timers.interval");
@@ -1251,6 +1244,13 @@ duk_ret_t ILibDuktape_Polyfills_timer_set(duk_context *ctx)
 		metadata = "setTimeout()";
 		break;
 	}
+
+	// save all timer references so they can't be GC'd while running
+	duk_push_heap_stash(ctx);															//[retVal][stash]
+	duk_dup(ctx, -2);																	//[retVal][stash][timer]
+	duk_put_prop_string(ctx, -2, Duktape_GetStashKey(duk_get_heapptr(ctx, -1)));		//[retVal][stash]
+	duk_pop(ctx);																		//[retVal]
+
 	ILibDuktape_CreateFinalizer(ctx, ILibDuktape_Polyfills_timer_finalizer);
 	
 	ptrs = (ILibDuktape_Timer*)Duktape_PushBuffer(ctx, sizeof(ILibDuktape_Timer));	//[retVal][ptrs]
@@ -1309,12 +1309,10 @@ duk_ret_t ILibDuktape_Polyfills_timer_clear(duk_context *ctx)
 	duk_get_prop_string(ctx, 0, ILibDuktape_Timer_Ptrs);
 	ptrs = (ILibDuktape_Timer*)Duktape_GetBuffer(ctx, -1, NULL);
 
-	if (ptrs->timerType == ILibDuktape_Timer_Type_IMMEDIATE)
-	{
-		duk_push_heap_stash(ctx);
-		duk_del_prop_string(ctx, -1, Duktape_GetStashKey(ptrs->object));
-		duk_pop(ctx);
-	}
+	// release timer reference so it can be GC'd
+	duk_push_heap_stash(ctx);
+	duk_del_prop_string(ctx, -1, Duktape_GetStashKey(ptrs->object));
+	duk_pop(ctx);
 
 	ILibLifeTime_Remove(ILibGetBaseTimer(Duktape_GetChain(ctx)), ptrs);
 	return 0;


### PR DESCRIPTION
Only setImmediate was pinned in the heap stash, so setTimeout/setInterval objects the caller didn't reference could be garbage-collected and silently cancelled by their finalizer, making fire-and-forget timers fire only if fired before GC collected them. Root all three types at creation and release on fire/clear (timer_set/timer_elapsed/timer_clear).
And it's behavior is like node now.

The original intent probably was to prevent forever running timers or something like that. but that introduced unreliable timers and is not expected behavior. See for example:

- modules_meshcore/amt-manage.js:71 — AMT MEI rebind retry

`if (rebindToMeiRetrys < 10) { setTimeout(obj.reset, 10000); }`
Fully fire-and-forget, no assignment.
When reading the Intel AMT/MEI version fails, this schedules a retry (obj.reset) in 10 s, up to 10 attempts. If the GC cancelled it, the retry never runs — agent silently stops trying to rebind to AMT and management features stay dead until something else forces it. This fix guarantees the retry fires.

- modules/amt-scanner.js:97 — AMT network-scan completion

`var tmout = setTimeout(function cb() { server.close(); if (callback) callback(server.scanResults); server.parent.emit('found', server.scanResults); ... }, timeout);`
tmout is a local in the scan method, which returns immediately. So after return the handle is unreferenced. This timer is the scan's finish: it closes the UDP socket, delivers results via callback, and emits 'found'. If the GC cancelled it, the scan never completes. Socket leaks, the caller's callback never fires (hangs waiting), no 'found'. This fix guarantees completion.

- modules/toaster.js:324 — Windows toast auto-dismiss/exit

`var t = setTimeout(function (b) { b.remove(); process.exit(); }, 7000, balloon);`
Local t in a function that returns. This is the fallback that removes the notification balloon and exits the helper after 7s if the user doesn't dismiss it first. If the GC cancelled it, an undismissed toast never auto-cleans and the helper process lingers. This fix guarantees the 7s cleanup.
 
Tested on linux & windows.

Test:
var ticks=0;
setTimeout(function () { console.log('setTimeout fired'); }, 5300);
setInterval(function () { console.log('setInterval tick ' + (++ticks)); }, 1000);

N.B.: the timers in the above examples could probably also be fixed in their respective scripts.

And AI was used to check the changes and find the examples.
