### PR TITLE
Fix FreeBSD build workflow

### DIFF
--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -19,7 +19,12 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           release: "13.5"
-          prepare: pkg install -y gmake
+          # The makefile generates ILibDuktape_Commit.h only when git works — without git the
+          # build fails on a missing header. safe.directory is needed because the rsynced
+          # repo is owned by the runner uid, not the VM user, so git refuses it otherwise.
+          prepare: |
+            pkg install -y gmake git
+            git config --global --add safe.directory '*'
           run: gmake -j4 freebsd ARCHID=30
       - name: Upload artifacts
         uses: actions/upload-artifact@v7.0.1


### PR DESCRIPTION
<!--
⚠️ NO AI SLOP!!!
⚠️ If you didn't do manual QA and testing on this PR you shouldn't be PRing
-->

# Summary

In this pull request, the following changes are made:

Install git and configure `safe.directory` to resolve missing header issue.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [ ] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [ ] 📦 If I changed JavaScript modules under `modules/`, I re-embedded them so the compiled-in copies in
      `microscript/ILibDuktape_Polyfills.c` match (the agent runs the embedded copies, not the files on disk).
- [ ] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [ ] 📄 Documentation updates are included (if applicable), e.g. the `.msh` options table in [readme.md](../readme.md).
- [ ] 🧰 Updates to vendored dependencies (OpenSSL, zlib, ...) are listed and explained.
- [ ] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>