### PR TITLE
Fix agent failover getting stuck on one MeshServer entry with no proxy

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -4011,6 +4011,10 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 			useproxy = len;
 		}
 	}
+	else
+	{
+		agent->triedNoProxy_Index = agent->serverIndex;
+	}
 #ifndef MICROSTACK_NOTLS
 	ILibParseUriResult result = ILibParseUri(serverUrl, &host, &port, &path, useproxy ? NULL : &meshServer);
 #else


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Set `triedNoProxy_Index = serverIndex` when no proxy is configured, so the existing round-robin check isn't permanently stuck and the agent can actually fail over to the next `MeshServer=` entry.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [x] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [ ] 📦 If I changed JavaScript modules under `modules/`, I re-embedded them so the compiled-in copies in
      `microscript/ILibDuktape_Polyfills.c` match (the agent runs the embedded copies, not the files on disk).
- [x] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [ ] 📄 Documentation updates are included (if applicable), e.g. the `.msh` options table in [readme.md](../readme.md).
- [ ] 🧰 Updates to vendored dependencies (OpenSSL, zlib, ...) are listed and explained.
- [x] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>

## Testing

MeshCentral server version 1.2.5
Used 2 meshcentral server urls as "MeshServer" msh option seperated by commas (and ServerID as well)

Without this fix, the agent picks a random server on startup, but if that one fails, it never fails over to the next server in the list, it just keeps retrying the same one forever, unless a proxy is configured.

| Platform (OS / distro / arch) | Tested | Result |
| ----------------------------- | ------ | ------ |
| Windows 11 x64           | ✅     | ✅     |
