### PR TITLE
Add an optional mTLS client certificate for server connections

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -2428,6 +2428,36 @@ int agent_VerifyMeshCertificates(MeshAgentHostContainer *agent)
 	if (i != 1) { return 1; } // Bad certificates
 	return 0;
 }
+
+// Load the optional mTLS client certificate. This is only used for the outgoing connection to
+// the server, it does not replace the agent certificate and has no effect on the NodeID.
+// The PEM file has to hold the private key first, followed by the certificate.
+void agent_LoadClientCertificate(MeshAgentHostContainer *agent)
+{
+	char certfile[1024];
+	int len;
+
+	agent->clientcert.flags = 0;
+	agent->clientcert.x509 = NULL;
+	agent->clientcert.pkey = NULL;
+
+	if (agent->masterDb == NULL) { return; }
+	len = ILibSimpleDataStore_Get(agent->masterDb, "ClientCertPem", NULL, 0);
+	if (len <= 0 || len >= (int)sizeof(certfile)) { return; }
+
+	ILibSimpleDataStore_Get(agent->masterDb, "ClientCertPem", certfile, (int)sizeof(certfile));
+	certfile[sizeof(certfile) - 1] = 0;
+
+	if (util_from_pem(certfile, &(agent->clientcert)) == -1)
+	{
+		// util_from_pem does not clean up after itself, so the key may be set even on failure
+		if (agent->clientcert.pkey != NULL) { EVP_PKEY_free(agent->clientcert.pkey); agent->clientcert.pkey = NULL; }
+		agent->clientcert.x509 = NULL;
+		ILIBLOGMESSAGEX("Unable to load mTLS client certificate: %s", certfile);
+		return;
+	}
+	ILIBLOGMESSAGEX("Loaded mTLS client certificate: %s", certfile);
+}
 #endif
 
 
@@ -5371,7 +5401,11 @@ int MeshAgent_AgentMode(MeshAgentHostContainer *agentHost, int paramLen, char **
 #endif
 
 #ifndef MICROSTACK_NOTLS
-	if (agentHost->selftlscert.x509 == NULL) {
+	agent_LoadClientCertificate(agentHost);
+	if (agentHost->clientcert.x509 != NULL) {
+		// An mTLS client certificate was configured, use that one instead.
+		ILibWebClient_EnableHTTPS(agentHost->httpClientManager, &(agentHost->clientcert), NULL, ValidateMeshServer, agentHost);
+	} else if (agentHost->selftlscert.x509 == NULL) {
 		// We don't have a TLS certificate, so setup the client without one.
 		ILibWebClient_EnableHTTPS(agentHost->httpClientManager, NULL, NULL, ValidateMeshServer, agentHost);
 	} else {
@@ -6358,6 +6392,7 @@ int MeshAgent_Start(MeshAgentHostContainer *agentHost, int paramLen, char **para
 void MeshAgent_Destroy(MeshAgentHostContainer* agent)
 {
 #ifndef MICROSTACK_NOTLS
+	util_freecert(&agent->clientcert);
 	util_freecert(&agent->selftlscert);
 	util_freecert(&agent->selfcert);
 #endif

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -2456,6 +2456,9 @@ void agent_LoadClientCertificate(MeshAgentHostContainer *agent)
 		ILIBLOGMESSAGEX("Unable to load mTLS client certificate: %s", certfile);
 		return;
 	}
+
+	// Also hand it to the script engine, the relay tunnels are opened from there
+	ILibDuktape_ClientCert = &(agent->clientcert);
 	ILIBLOGMESSAGEX("Loaded mTLS client certificate: %s", certfile);
 }
 #endif
@@ -6392,6 +6395,7 @@ int MeshAgent_Start(MeshAgentHostContainer *agentHost, int paramLen, char **para
 void MeshAgent_Destroy(MeshAgentHostContainer* agent)
 {
 #ifndef MICROSTACK_NOTLS
+	ILibDuktape_ClientCert = NULL;
 	util_freecert(&agent->clientcert);
 	util_freecert(&agent->selftlscert);
 	util_freecert(&agent->selfcert);

--- a/meshcore/agentcore.h
+++ b/meshcore/agentcore.h
@@ -225,6 +225,7 @@ typedef struct MeshAgentHostContainer
 #endif
 	struct util_cert selfcert;
 	struct util_cert selftlscert;
+	struct util_cert clientcert;			// Optional mTLS client cert, set with the "ClientCertPem" setting
 	char serverWebHash[UTIL_SHA384_HASHSIZE];
 #endif
 

--- a/microscript/ILibDuktape_net.c
+++ b/microscript/ILibDuktape_net.c
@@ -87,6 +87,12 @@ typedef struct ILibDuktape_net_server_session
 int ILibDuktape_TLS_ctx2socket = -1;
 int ILibDuktape_TLS_ctx2server = -1;
 
+#ifndef MICROSTACK_NOTLS
+// Optional mTLS client certificate, set by the agent when "ClientCertPem" is configured.
+// Only used for outgoing TLS connections, see ILibDuktape_TLS_connect().
+struct util_cert *ILibDuktape_ClientCert = NULL;
+#endif
+
 #ifdef WIN32
 #define ILibDuktape_net_IPC_BUFFERSIZE	4096
 typedef struct ILibDuktape_net_WindowsIPC
@@ -2451,7 +2457,16 @@ duk_ret_t ILibDuktape_TLS_connect(duk_context *ctx)
 	{
 		return(ILibDuktape_Error(ctx, "Invalid SecureContext Object"));
 	}
-	SSL_CTX_set_verify(data->ssl_ctx, SSL_VERIFY_PEER, ILibDuktape_TLS_verify); /* Ask for authentication */																					
+	SSL_CTX_set_verify(data->ssl_ctx, SSL_VERIFY_PEER, ILibDuktape_TLS_verify); /* Ask for authentication */
+
+	// If the agent has an mTLS client certificate, present it on outgoing connections. The caller
+	// can still supply its own certificate with "pfx", in that case we leave it alone.
+	if ((ILibDuktape_ClientCert != NULL) && (ILibDuktape_ClientCert->x509 != NULL) && (duk_has_prop_string(ctx, 0, "pfx") == 0))
+	{
+		SSL_CTX_use_certificate(data->ssl_ctx, ILibDuktape_ClientCert->x509);
+		SSL_CTX_use_PrivateKey(data->ssl_ctx, ILibDuktape_ClientCert->pkey);
+	}
+
 	if (duk_has_prop_string(ctx, 0, "ALPNProtocols"))
 	{
 		duk_uarridx_t i;

--- a/microscript/ILibDuktape_net.h
+++ b/microscript/ILibDuktape_net.h
@@ -28,6 +28,12 @@ limitations under the License.
 #define ILibDuktape_SOCKET2OPTIONS	"\xFF_NET_SOCKET2OPTIONS"
 void ILibDuktape_net_init(duk_context *ctx, void *chain);
 
+#ifndef MICROSTACK_NOTLS
+// Optional mTLS client certificate used for outgoing TLS connections made from the script engine
+struct util_cert;
+extern struct util_cert *ILibDuktape_ClientCert;
+#endif
+
 typedef struct ILibDuktape_globalTunnel_data
 {
 	struct sockaddr_in6 proxyServer;

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Here is a list of the possible keys that are currently supported by the agent. N
 |---|---|
 | `AgentCapabilities` | Bitmask specifying supported agent capabilities. |
 | `agentName` | If set, sent to the server instead of the hostname. |
-| `ClientCertPem` | Path to a PEM file holding a private key followed by a certificate. If set, this certificate is presented as the TLS client certificate when connecting to the server, for example when the server sits behind a reverse proxy that requires mTLS. Does not affect the agent identity certificate or the NodeID. |
+| `ClientCertPem` | Path to a PEM file holding a private key followed by a certificate. If set, this certificate is presented as the TLS client certificate on the control channel and on relay tunnels, for example when the server sits behind a reverse proxy that requires mTLS. Does not affect the agent identity certificate or the NodeID. |
 | `compactDirtyMinimum` | Minimum dirty bytes threshold for the `db.compact()` operation. |
 | `consoleTextMaxRate` | Rate limit for `sendConsoleText`. Default is 10 messages per second. |
 | `controlChannelDebug` | If set, logs/displays control channel messages (except JSON messages). |

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ Here is a list of the possible keys that are currently supported by the agent. N
 |---|---|
 | `AgentCapabilities` | Bitmask specifying supported agent capabilities. |
 | `agentName` | If set, sent to the server instead of the hostname. |
+| `ClientCertPem` | Path to a PEM file holding a private key followed by a certificate. If set, this certificate is presented as the TLS client certificate when connecting to the server, for example when the server sits behind a reverse proxy that requires mTLS. Does not affect the agent identity certificate or the NodeID. |
 | `compactDirtyMinimum` | Minimum dirty bytes threshold for the `db.compact()` operation. |
 | `consoleTextMaxRate` | Rate limit for `sendConsoleText`. Default is 10 messages per second. |
 | `controlChannelDebug` | If set, logs/displays control channel messages (except JSON messages). |


### PR DESCRIPTION
# Summary

Putting a MeshCentral server behind a reverse proxy that requires a client certificate doesn't
work today. The agent does present a TLS client certificate on the control channel, but it is the
self-signed selftlscert issued by its own root, so a proxy validating against a real CA rejects
it. This adds an optional certificate for that case. Without the new setting nothing changes.

Changes:

- Added a ClientCertPem setting, pointing at a PEM file holding a private key followed by a
  certificate. When set, it is loaded in agent_LoadClientCertificate() and presented on outgoing
  connections to the server.
- The control channel goes through httpClientManager, so ILibWebClient_EnableHTTPS() gets that
  certificate instead of selftlscert.
- Relay tunnels needed the same treatment, which was not obvious: they are opened from the script
  engine, meshcore calls http.request which ends up in https.Agent -> tls.connect. Without
  covering that path, remote desktop, terminal and files fail while the agent still shows online.
- The tunnel side is attached in ILibDuktape_TLS_connect() rather than in
  tls.createSecureContext(), because createSecureContext() is also used by tls.createServer(),
  where setting a certificate would turn it into the agent's server certificate. A caller
  passing its own pfx still takes precedence.
- selfcert, selftlscert and agent_VerifyMeshCertificates() are untouched, so the NodeID and the
  existing certificate chain are unaffected.
- Documented ClientCertPem in the .msh options table in readme.md.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [x] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [ ] 📦 If I changed JavaScript modules under `modules/`, I re-embedded them so the compiled-in copies in
      `microscript/ILibDuktape_Polyfills.c` match (the agent runs the embedded copies, not the files on disk).
- [x] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [x] 📄 Documentation updates are included (if applicable), e.g. the `.msh` options table in [readme.md](../readme.md).
- [ ] 🧰 Updates to vendored dependencies (OpenSSL, zlib, ...) are listed and explained.
- [x] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>

## Testing

Tested against MeshCentral v1.2.4 behind nginx with ssl_client_certificate and
ssl_verify_client optional, returning 403 for anything without a valid client certificate, on the
whole vhost including /agent.ashx and /meshrelay.ashx.

- Control channel connects and completes authentication.
- Remote desktop works, and the agent holds two connections (control channel plus tunnel). Since
  /meshrelay.ashx returns 403 without a certificate, the tunnel demonstrably presents it.
- Negative test: with the PEM renamed away the agent logs "Unable to load mTLS client certificate"
  and gets no connection at all. Renaming it back restores both.
- Agent self-test (run --selfTest=1) passes, including Tunnel, Terminal, KVM and File Transfer.
- Without ClientCertPem set, behaviour is unchanged.

| Platform (OS / distro / arch) | Tested | Result |
| ----------------------------- | ------ | ------ |
| Windows 11 x64 (26200)        | ✅     | Control channel, relay tunnels and self-test all pass over mTLS |
| Ubuntu 24.04 x64              | ➖     | Compiles clean with no new warnings, did not test the agent on the plattform |
| macOS / FreeBSD               | ➖     | CI builds only |