### PR TITLE
Fix unaligned scalar access on strict-alignment CPUs

### DIFF
--- a/meshcore/KVM/Linux/linux_kvm.c
+++ b/meshcore/KVM/Linux/linux_kvm.c
@@ -843,8 +843,8 @@ int kvm_server_inputdata(char* block, int blocklen)
 
 	// Decode the block header
 	if (blocklen < 4) return 0;
-	type = ntohs(((unsigned short*)(block))[0]);
-	size = ntohs(((unsigned short*)(block))[1]);
+	type = ntohs(ILibUnaligned_Read16(block));
+	size = ntohs(ILibUnaligned_Read16(block + 2));
 	if (size > blocklen) return 0;
 
 	switch (type)
@@ -873,9 +873,9 @@ int kvm_server_inputdata(char* block, int blocklen)
 			if (size == 10 || size == 12)
 			{
 				// Client sends coords relative to the captured region; translate to absolute screen coords
-				x = ((int)ntohs(((unsigned short*)(block))[3])) + CAPTURE_X;
-				y = ((int)ntohs(((unsigned short*)(block))[4])) + CAPTURE_Y;
-				if (size == 12) w = ((short)ntohs(((short*)(block))[5]));
+				x = ((int)ntohs(ILibUnaligned_Read16(block + 6))) + CAPTURE_X;
+				y = ((int)ntohs(ILibUnaligned_Read16(block + 8))) + CAPTURE_Y;
+				if (size == 12) w = ((short)ntohs(ILibUnaligned_Read16(block + 10)));
 				if (logFile) { fprintf(logFile, "RemoteMouseMove: (%d, %d)\n", x, y); }
 				// printf("x:%d, y:%d, b:%d, w:%d\n", x, y, block[5], w);
 				if (g_enableEvents)
@@ -888,8 +888,8 @@ int kvm_server_inputdata(char* block, int blocklen)
 		}
 	case MNG_KVM_COMPRESSION: // Compression
 		{
-			if (size >= 10) { int fr = ((int)ntohs(((unsigned short*)(block + 8))[0])); if (fr >= 20 && fr <= 5000) FRAME_RATE_TIMER = fr; }
-			if (size >= 8) { int ns = ((int)ntohs(((unsigned short*)(block + 6))[0])); if (ns >= 64 && ns <= 4096) SCALING_FACTOR_NEW = ns; }
+			if (size >= 10) { int fr = ((int)ntohs(ILibUnaligned_Read16(block + 8))); if (fr >= 20 && fr <= 5000) FRAME_RATE_TIMER = fr; }
+			if (size >= 8) { int ns = ((int)ntohs(ILibUnaligned_Read16(block + 6))); if (ns >= 64 && ns <= 4096) SCALING_FACTOR_NEW = ns; }
 			if (size >= 6) { set_tile_compression((int)block[4], (int)block[5]); }
 			COMPRESSION_RATIO = 100;
 			break;
@@ -922,7 +922,7 @@ int kvm_server_inputdata(char* block, int blocklen)
 		}
 	case MNG_KVM_FRAME_RATE_TIMER:
 		{
-			int fr = ((int)ntohs(((unsigned short*)(block))[2]));
+			int fr = ((int)ntohs(ILibUnaligned_Read16(block + 4)));
 			if (fr >= 20 && fr <= 5000) FRAME_RATE_TIMER = fr;
 			break;
 		}
@@ -933,7 +933,7 @@ int kvm_server_inputdata(char* block, int blocklen)
 		}
 	case MNG_KVM_SET_DISPLAY:
 		{
-			unsigned short newval = ntohs(((unsigned short*)(block))[2]);
+			unsigned short newval = ntohs(ILibUnaligned_Read16(block + 4));
 			if (g_monitor_count > 0)
 			{
 				// XRandR mode: 65535 = all monitors, 1..N = specific physical monitor
@@ -1553,13 +1553,13 @@ void kvm_relay_readSink(ILibProcessPipe_Pipe sender, char *buffer, size_t buffer
 
 	if (bufferLen > 4)
 	{
-		if (ntohs(((unsigned short*)(buffer))[0]) == (unsigned short)MNG_JUMBO)
+		if (ntohs(ILibUnaligned_Read16(buffer)) == (unsigned short)MNG_JUMBO)
 		{
 			if (bufferLen > 8)
 			{
-				if (bufferLen >= (8 + (int)ntohl(((unsigned int*)(buffer))[1])))
+				if (bufferLen >= (8 + (int)ntohl(ILibUnaligned_Read32(buffer + 4))))
 				{
-					*bytesConsumed = 8 + (int)ntohl(((unsigned int*)(buffer))[1]);
+					*bytesConsumed = 8 + (int)ntohl(ILibUnaligned_Read32(buffer + 4));
 					writeHandler(buffer, *bytesConsumed, reserved);
 					return;
 				}
@@ -1567,7 +1567,7 @@ void kvm_relay_readSink(ILibProcessPipe_Pipe sender, char *buffer, size_t buffer
 		}
 		else
 		{
-			size = ntohs(((unsigned short*)(buffer))[1]);
+			size = ntohs(ILibUnaligned_Read16(buffer + 2));
 			if (size <= bufferLen)
 			{
 				*bytesConsumed = size;

--- a/meshcore/KVM/Linux/linux_tile.c
+++ b/meshcore/KVM/Linux/linux_tile.c
@@ -143,23 +143,26 @@ void dump32bit (const XImage * input)
 int util_crc(int x, int y, long long bufferSize, void *desktop, long long desktopsize, int tilewidth, int tileheight)
 {
     int hval = 0;
-    int *bp = NULL;
-    int *be = NULL;
+    char *bp = NULL;
+    char *be = NULL;
     int height = 0;
 
+    // Walked as bytes: the row stride is 3 bytes per pixel, so these 32 bit reads land on
+    // arbitrary addresses and must not be issued through an int* (SIGBUS on MIPS/ARMv5).
     for (height = y; height < y + tileheight; height++) {
-    	bp = (int *)(((char *)desktop) + (3 * ((height * adjust_screen_size(SCREEN_WIDTH)) + x)));
-    	be = (int *)(((char *)desktop) + (3 * ((height * adjust_screen_size(SCREEN_WIDTH)) + x + tilewidth)));
-    	while ((bp + 1) <= be)
+    	bp = ((char *)desktop) + (3 * ((height * adjust_screen_size(SCREEN_WIDTH)) + x));
+    	be = ((char *)desktop) + (3 * ((height * adjust_screen_size(SCREEN_WIDTH)) + x + tilewidth));
+    	while ((bp + 4) <= be)
 		{
 			// hval *= 0x01000193;
 			hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
-			hval ^= *bp++;
+			hval ^= (int)ILibUnaligned_Read32(bp);
+			bp += 4;
 		}
 
     	if (be - bp >= 0) {
     		hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
-    		hval ^= (*(int *)(((char *)be) - 3));
+    		hval ^= (int)ILibUnaligned_Read32(be - 3);
     	}
     }
 

--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -895,7 +895,7 @@ ILibTransport_DoneState ILibDuktape_MeshAgent_RemoteDesktop_KVM_WriteSink(char *
 	}
 #endif
 
-	if ((buffer != NULL) && (bufferLen > 4) && (ntohs(((unsigned short*)buffer)[0]) == MNG_DEBUG))
+	if ((buffer != NULL) && (bufferLen > 4) && (ntohs(ILibUnaligned_Read16(buffer)) == MNG_DEBUG))
 	{
 		Duktape_Console_LogEx(ptrs->ctx, ILibDuktape_LogType_Info1, "%s", buffer + 4);
 	}
@@ -1117,7 +1117,7 @@ duk_ret_t ILibDuktape_MeshAgent_getRemoteDesktop_DomainIPC_DataSink(duk_context 
 	// We need to properly frame the data before we propagate it up
 	if (bufferLen > 4)
 	{
-		size = ntohs(((unsigned short*)(buffer))[1]);
+		size = ntohs(ILibUnaligned_Read16(buffer + 2));
 		if (size <= bufferLen)
 		{
 			// We have all the data, to be able to frame it
@@ -2589,13 +2589,13 @@ int GenerateSHA384FileHash(char *filePath, char *fileHash)
 	if (checkSumIndex != 0)
 	{
 		bytesRead = fread(ILibScratchPad, 1, checkSumIndex + 4, tmpFile);
-		((unsigned int*)(ILibScratchPad + checkSumIndex))[0] = 0;
+		ILibUnaligned_Write32(ILibScratchPad + checkSumIndex, 0);
 		SHA384_Update(&ctx, ILibScratchPad, bytesRead);
 		if (endIndex > 0) { bytesLeft -= (unsigned int)bytesRead; }
 
 		bytesRead = fread(ILibScratchPad, 1, tableIndex + 8 - (checkSumIndex + 4), tmpFile);
-		((unsigned int*)(ILibScratchPad + bytesRead - 8))[0] = 0;
-		((unsigned int*)(ILibScratchPad + bytesRead - 8))[1] = 0;
+		ILibUnaligned_Write32(ILibScratchPad + bytesRead - 8, 0);
+		ILibUnaligned_Write32(ILibScratchPad + bytesRead - 4, 0);
 		SHA384_Update(&ctx, ILibScratchPad, bytesRead);
 		if (endIndex > 0) { bytesLeft -= (unsigned int)bytesRead; }
 	}
@@ -2862,7 +2862,7 @@ duk_ret_t MeshServer_selfupdate_unzip_error(duk_context *ctx)
 // Process MeshCentral server commands. 
 void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAgentHostContainer *agent, char *cmd, int cmdLen)
 {
-	unsigned short command = ntohs(((unsigned short*)cmd)[0]);
+	unsigned short command = ntohs(ILibUnaligned_Read16(cmd));
 	unsigned short requestid;
 
 	if (agent->controlChannelDebug != 0)
@@ -3125,7 +3125,7 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 
 	// All these commands must have both a commandid and a requestid
 	if (cmdLen < 4) return;
-	requestid = ntohs(((unsigned short*)cmd)[1]);
+	requestid = ntohs(ILibUnaligned_Read16(cmd + 2));
 
 	if (agent->controlChannelDebug != 0) 
 	{
@@ -4472,7 +4472,7 @@ int importSettings(MeshAgentHostContainer *agent, char* fileName)
 					}
 					else
 					{
-						if (valLen > 2 && ntohs(((unsigned short*)val)[0]) == HEX_IDENTIFIER)
+						if (valLen > 2 && ntohs(ILibUnaligned_Read16(val)) == HEX_IDENTIFIER)
 						{
 							// HEX value
 							ILibSimpleDataStore_PutEx(agent->masterDb, key, keyLen, ILibScratchPad2, util_hexToBuf(val + 2, valLen - 2, ILibScratchPad2));
@@ -5867,7 +5867,7 @@ void MeshAgent_ScriptMode(MeshAgentHostContainer *agentHost, int argc, char **ar
 			else if (strncmp(argv[i], "--script-flags", 14) == 0 && ((i + 1) < argc))
 			{
 				// JS Permissions (see .h for values)
-				if (ntohs(((unsigned short*)argv[i + 1])[0]) == HEX_IDENTIFIER)
+				if (ntohs(ILibUnaligned_Read16(argv[i + 1])) == HEX_IDENTIFIER)
 				{
 					int xlen = (int)strnlen_s(argv[i + 1], 32);
 					if (xlen <= 10)
@@ -6073,7 +6073,9 @@ int MeshAgent_System(char *cmd)
 int MeshAgent_Start(MeshAgentHostContainer *agentHost, int paramLen, char **param)
 {
 	char *startParms = NULL;
-	char _exedata[ILibMemory_Init_Size(1024, sizeof(void*))];
+	// void* element type guarantees the pointer alignment ILibMemory blocks require (a plain
+	// char array only guarantees alignment 1, and ILibMemory_CanaryOK rejects misaligned blocks)
+	void *_exedata[(ILibMemory_Init_Size(1024, sizeof(void*)) + sizeof(void*) - 1) / sizeof(void*)];
 	char *exePath = ILibMemory_Init(_exedata, 1024, sizeof(void*), ILibMemory_Types_STACK);
 	((void**)ILibMemory_Extra(exePath))[0] = agentHost;
 

--- a/microscript/ILibDuktape_GenericMarshal.c
+++ b/microscript/ILibDuktape_GenericMarshal.c
@@ -489,10 +489,10 @@ duk_ret_t ILibDuktape_GenericMarshal_Variable_Val_SET(duk_context *ctx)
 		switch (size)
 		{
 		case 2:
-			((unsigned short*)ptr)[0] = (unsigned short)duk_require_int(ctx, 0);
+			ILibUnaligned_Write16(ptr, (unsigned short)duk_require_int(ctx, 0));
 			break;
 		case 4:
-			((unsigned int*)ptr)[0] = (unsigned int)duk_require_int(ctx, 0);
+			ILibUnaligned_Write32(ptr, (unsigned int)duk_require_int(ctx, 0));
 			break;
 		default:
 			return(ILibDuktape_Error(ctx, "Unsupported VAL size, with integral type"));
@@ -568,10 +568,10 @@ duk_ret_t ILibDuktape_GenericMarshal_Variable_GetEx(duk_context *ctx)
 	switch (varSize)
 	{
 	case 2:
-		duk_push_int(ctx, (int)((unsigned short*)ptr)[0]);
+		duk_push_int(ctx, (int)ILibUnaligned_Read16(ptr));
 		break;
 	case 4:
-		duk_push_int(ctx, (int)((unsigned int*)ptr)[0]);
+		duk_push_int(ctx, (int)ILibUnaligned_Read32(ptr));
 		break;
 	default:
 		return(ILibDuktape_Error(ctx, "Invalid Variable"));
@@ -595,10 +595,10 @@ duk_ret_t ILibDuktape_GenericMarshal_Variable_SetEx(duk_context *ctx)
 	switch (varSize)
 	{
 	case 2:
-		((unsigned short*)ptr)[0] = (unsigned short)newVal;
+		ILibUnaligned_Write16(ptr, (unsigned short)newVal);
 		break;
 	case 4:
-		((unsigned int*)ptr)[0] = (unsigned int)newVal;
+		ILibUnaligned_Write32(ptr, (unsigned int)newVal);
 		break;
 	default:
 		return(ILibDuktape_Error(ctx, "Invalid Variable"));

--- a/microscript/ILibDuktape_HttpStream.c
+++ b/microscript/ILibDuktape_HttpStream.c
@@ -4099,7 +4099,7 @@ duk_ret_t ILibDuktape_httpStream_parseUri(duk_context *ctx)
 ILibTransport_DoneState ILibDuktape_httpStream_webSocket_WriteWebSocketPacket(ILibDuktape_WebSocket_State *state, int opcode, char *_buffer, int _bufferLen, ILibWebClient_WebSocket_FragmentFlags _bufferFragment)
 {
 	char header[10];
-	int maskKeyInt;
+	uint32_t maskKeyInt;
 	int headerLen = 0;
 	unsigned short flags = state->noMasking == 0 ? WEBSOCKET_MASK : 0;
 
@@ -4198,13 +4198,13 @@ ILibTransport_DoneState ILibDuktape_httpStream_webSocket_WriteWebSocketPacket(IL
 
 		// Mask the payload
 		util_random(4, maskKey);
-		maskKeyInt = ((int*)(maskKey))[0];
-		if (bufferLen > 0) 
+		maskKeyInt = ILibUnaligned_Read32(maskKey);
+		if (bufferLen > 0)
 		{
 			int x;
-			// Note that the line below will cause a SegFault on Linux when compiled with GCC -O3, the fault happens at the XOR (^) operation.
-			// Compiling with -O2 works also, doing the masking operating byte-by-byte also works with -O3.
-			for (x = 0; x < (bufferLen >> 2); ++x) { ((int*)(dataFrame+headerLen+4))[x] = ((int*)buffer)[x] ^ (int)maskKeyInt; } // Mask 4 bytes at a time (SegFaults with -O3).
+			// maskKey/dataFrame/buffer all sit at runtime offsets, so the 4-byte-at-a-time masking below
+			// must not be done through pointer casts (it faulted with GCC -O3, and traps on MIPS/ARMv5).
+			for (x = 0; x < (bufferLen >> 2); ++x) { ILibUnaligned_Write32(dataFrame + headerLen + 4 + (x << 2), ILibUnaligned_Read32(buffer + (x << 2)) ^ maskKeyInt); } // Mask 4 bytes at a time
 			for (x = (x << 2); x < bufferLen; ++x) { dataFrame[x + headerLen + 4] = buffer[x] ^ maskKey[x % 4]; } // Mask the reminder
 		}
 		retVal = ILibDuktape_DuplexStream_WriteData(state->encodedStream, dataFrame, headerLen + 4 + bufferLen) == 0 ? ILibTransport_DoneState_COMPLETE : ILibTransport_DoneState_INCOMPLETE;
@@ -4342,7 +4342,7 @@ ILibTransport_DoneState ILibDuktape_httpStream_webSocket_EncodedWriteSink(ILibDu
 		return(ILibDuktape_httpStream_webSocket_EncodedWriteSink_DispatchUnshift(stream, buffer, bufferLen));
 	} 
 
-	hdr = ntohs(((unsigned short*)(buffer))[0]);
+	hdr = ntohs(ILibUnaligned_Read16(buffer));
 	FIN = (hdr & WEBSOCKET_FIN) != 0;
 	OPCODE = (hdr & WEBSOCKET_OPCODE) >> 8;
 	RSV = (hdr & WEBSOCKET_RSV) >> 8;
@@ -4359,7 +4359,7 @@ ILibTransport_DoneState ILibDuktape_httpStream_webSocket_EncodedWriteSink(ILibDu
 	if (plen == 126)
 	{
 		if (bufferLen < 4) { return(ILibDuktape_httpStream_webSocket_EncodedWriteSink_DispatchUnshift(stream, buffer, bufferLen)); } // We need at least 4 bytes to read enough of the headers
-		plen = (unsigned short)ntohs(((unsigned short*)(buffer))[1]);
+		plen = (unsigned short)ntohs(ILibUnaligned_Read16(buffer + 2));
 		i += 2;
 	}
 	else if (plen == 127)
@@ -4370,7 +4370,7 @@ ILibTransport_DoneState ILibDuktape_httpStream_webSocket_EncodedWriteSink(ILibDu
 		}
 		else
 		{
-			unsigned long long v = ILibNTOHLL(((unsigned long long*)(buffer + 2))[0]);
+			unsigned long long v = ILibNTOHLL(ILibUnaligned_Read64(buffer + 2));
 			if (v > 0x7FFFFFFFUL)
 			{
 				// this value is too big to store in a 32 bit signed variable, so disconnect the websocket.
@@ -4396,10 +4396,10 @@ ILibTransport_DoneState ILibDuktape_httpStream_webSocket_EncodedWriteSink(ILibDu
 		// Unmask the data
 		i += 4;	// Move ptr to start of data
 
-		int maskKeyInt = ((int*)(maskingKey))[0];
+		uint32_t maskKeyInt = ILibUnaligned_Read32(maskingKey);
 		if (plen > 0)
 		{
-			for (x = 0; x < (plen >> 2); ++x) { ((int*)(buffer+i))[x] = ((int*)(buffer+i))[x] ^ (int)maskKeyInt; } // Mask 4 bytes at a time
+			for (x = 0; x < (plen >> 2); ++x) { ILibUnaligned_Write32(buffer + i + (x << 2), ILibUnaligned_Read32(buffer + i + (x << 2)) ^ maskKeyInt); } // Mask 4 bytes at a time
 			for (x = (x << 2); x < plen; ++x) { buffer[x + i] = buffer[x + i] ^ maskingKey[x % 4]; } // Mask the reminder
 		}
 	}

--- a/microscript/ILibDuktape_Polyfills.c
+++ b/microscript/ILibDuktape_Polyfills.c
@@ -285,7 +285,7 @@ duk_ret_t ILibDuktape_Polyfills_Buffer_readInt32BE(duk_context *ctx)
 	duk_push_this(ctx);
 	buffer = Duktape_GetBuffer(ctx, -1, &bufferLen);
 
-	duk_push_int(ctx, ntohl(((int*)(buffer + offset))[0]));
+	duk_push_int(ctx, ntohl((int)ILibUnaligned_Read32(buffer + offset)));
 	return(1);
 }
 duk_ret_t ILibDuktape_Polyfills_Buffer_alloc(duk_context *ctx)
@@ -1072,7 +1072,7 @@ duk_ret_t ILibDuktape_ntohl(duk_context *ctx)
 	int offset = duk_require_int(ctx, 1);
 
 	if ((int)bufferLen < (4 + offset)) { return(ILibDuktape_Error(ctx, "buffer too small")); }
-	duk_push_int(ctx, ntohl(((unsigned int*)(buffer + offset))[0]));
+	duk_push_int(ctx, ntohl(ILibUnaligned_Read32(buffer + offset)));
 	return 1;
 }
 duk_ret_t ILibDuktape_ntohs(duk_context *ctx)
@@ -1082,7 +1082,7 @@ duk_ret_t ILibDuktape_ntohs(duk_context *ctx)
 	int offset = duk_require_int(ctx, 1);
 
 	if ((int)bufferLen < 2 + offset) { return(ILibDuktape_Error(ctx, "buffer too small")); }
-	duk_push_int(ctx, ntohs(((unsigned short*)(buffer + offset))[0]));
+	duk_push_int(ctx, ntohs(ILibUnaligned_Read16(buffer + offset)));
 	return 1;
 }
 duk_ret_t ILibDuktape_htonl(duk_context *ctx)
@@ -1093,7 +1093,7 @@ duk_ret_t ILibDuktape_htonl(duk_context *ctx)
 	unsigned int val = (unsigned int)duk_require_int(ctx, 2);
 
 	if ((int)bufferLen < (4 + offset)) { return(ILibDuktape_Error(ctx, "buffer too small")); }
-	((unsigned int*)(buffer + offset))[0] = htonl(val);
+	ILibUnaligned_Write32(buffer + offset, htonl(val));
 	return 0;
 }
 duk_ret_t ILibDuktape_htons(duk_context *ctx)
@@ -1104,7 +1104,7 @@ duk_ret_t ILibDuktape_htons(duk_context *ctx)
 	unsigned int val = (unsigned int)duk_require_int(ctx, 2);
 
 	if ((int)bufferLen < (2 + offset)) { return(ILibDuktape_Error(ctx, "buffer too small")); }
-	((unsigned short*)(buffer + offset))[0] = htons(val);
+	ILibUnaligned_Write16(buffer + offset, htons((unsigned short)val));
 	return 0;
 }
 void ILibDuktape_Polyfills_byte_ordering(duk_context *ctx)

--- a/microscript/ILibDuktape_ScriptContainer.c
+++ b/microscript/ILibDuktape_ScriptContainer.c
@@ -3089,7 +3089,7 @@ void ILibDuktape_ScriptContainer_Slave_ProcessCommands(ILibDuktape_ScriptContain
 	}
 	
 
-	duk_push_lstring(codec, buffer + 4, ((int*)buffer)[0] - 4);
+	duk_push_lstring(codec, buffer + 4, (int)ILibUnaligned_Read32(buffer) - 4);
 	duk_json_decode(codec, -1);
 	cmd = (SCRIPT_ENGINE_COMMAND)Duktape_GetIntPropertyValue(codec, -1, "command", SCRIPT_ENGINE_COMMAND_UNKNOWN);
 
@@ -3349,7 +3349,7 @@ void ILibDuktape_ScriptContainer_Slave_OnReadStdIn(ILibProcessPipe_Pipe sender, 
 	if (!ILibMemory_CanaryOK(sender)) { return; }
 
 	ILibDuktape_ScriptContainer_Slave *slave = (ILibDuktape_ScriptContainer_Slave*)((void**)ILibMemory_Extra(sender))[0];
-	if (bufferLen < 4 || bufferLen < (size_t)((int*)buffer)[0]) { return; }
+	if (bufferLen < 4 || bufferLen < (size_t)(int)ILibUnaligned_Read32(buffer)) { return; }
 	ILibRemoteLogging_printf(ILibChainGetLogger(slave->chain), ILibRemoteLogging_Modules_Microstack_Generic, ILibRemoteLogging_Flags_VerbosityLevel_1, "Slave read: %d bytes", bufferLen);
 
 #ifdef WIN32
@@ -3362,7 +3362,7 @@ void ILibDuktape_ScriptContainer_Slave_OnReadStdIn(ILibProcessPipe_Pipe sender, 
 	ILibDuktape_ScriptContainer_Slave_ProcessCommands(slave, buffer, sender);
 #endif
 	
-	*bytesConsumed = ((int*)buffer)[0];
+	*bytesConsumed = (int)ILibUnaligned_Read32(buffer);
 }
 
 int ILibDuktape_ScriptContainer_StartSlave(void *chain, ILibProcessPipe_Manager manager)
@@ -3496,7 +3496,7 @@ duk_ret_t ILibDuktape_ScriptContainer_Exit(duk_context *ctx)
 		duk_json_encode(ctx, -1);
 		buffer = (char*)duk_get_lstring(ctx, -1, &bufferLen);
 
-		((int*)header)[0] = (int)bufferLen + 4;
+		ILibUnaligned_Write32(header, (uint32_t)((int)bufferLen + 4));
 		ILibProcessPipe_Process_WriteStdIn(master->child, header, 4, ILibTransport_MemoryOwnership_USER);
 		ILibProcessPipe_Process_WriteStdIn(master->child, buffer, (int)bufferLen, ILibTransport_MemoryOwnership_USER);
 		//if (master->child != NULL) { ILibProcessPipe_Process_SoftKill(master->child); }
@@ -3640,7 +3640,7 @@ void ILibDuktape_ScriptContainer_StdErrSink_MicrostackThread(void *chain, void *
 {
 	ILibDuktape_ScriptContainer_Master *master = (ILibDuktape_ScriptContainer_Master*)((void**)user)[0];
 	char *buffer = (char*)((void**)user)[1];
-	int bufferLen = ((int*)buffer)[0];
+	int bufferLen = (int)ILibUnaligned_Read32(buffer);
 	void *ptr;
 	int i;
 	duk_context *ctx = master->ctx;
@@ -3737,9 +3737,9 @@ void ILibDuktape_ScriptContainer_StdErrSink(ILibProcessPipe_Process sender, char
 {
 	ILibDuktape_ScriptContainer_Master* master = (ILibDuktape_ScriptContainer_Master*)user;
 	
-	if (bufferLen < 4 || bufferLen < (size_t)((int*)buffer)[0]) { return; }
+	if (bufferLen < 4 || bufferLen < (size_t)(int)ILibUnaligned_Read32(buffer)) { return; }
 	
-	*bytesConsumed = ((int*)buffer)[0];
+	*bytesConsumed = (int)ILibUnaligned_Read32(buffer);
 #ifdef WIN32
 	if (ILibMemory_CanaryOK(sender))
 	{
@@ -4174,7 +4174,7 @@ duk_ret_t ILibDuktape_ScriptContainer_Create(duk_context *ctx)
 
 		duk_swap_top(ctx, -2);										// [json][container]
 
-		((int*)header)[0] = (int)bufferLen + 4;
+		ILibUnaligned_Write32(header, (uint32_t)((int)bufferLen + 4));
 		ILibProcessPipe_Process_AddHandlers(master->child, SCRIPT_ENGINE_PIPE_BUFFER_SIZE, ILibDuktape_ScriptContainer_ExitSink, ILibDuktape_ScriptContainer_StdOutSink, ILibDuktape_ScriptContainer_StdErrSink, ILibDuktape_ScriptContainer_SendOkSink, master);
 		ILibProcessPipe_Process_WriteStdIn(master->child, header, sizeof(header), ILibTransport_MemoryOwnership_USER);
 		ILibProcessPipe_Process_WriteStdIn(master->child, buffer, (int)bufferLen, ILibTransport_MemoryOwnership_USER);

--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -8597,7 +8597,7 @@ int ILibHashtable_DefaultBucketizer(int value)
 	unsigned char tmp[4];
 	int retVal = 0;
 
-	((unsigned int*)tmp)[0] = value;
+	ILibUnaligned_Write32(tmp, (uint32_t)value);
 	retVal = (int)(tmp[0] ^ tmp[1] ^ tmp[2] ^ tmp[3]); //Klocwork is being retarded, and doesn't realize an unsigned int is 4 bytes
 
 	return retVal;
@@ -8615,32 +8615,32 @@ int ILibHashtable_DefaultHashFunc(void* Key1, char* Key2, int Key2Len)
 	{
 		if (Key2Len < 5)
 		{
-			((int*)tmp)[0] = 0;
+			ILibUnaligned_Write32(tmp, 0);
 			for (i = 0; i < Key2Len; ++i)
 			{
 				tmp[i] = Key2[i];
 			}
-			retVal ^= ((int*)tmp)[0];
+			retVal ^= (int)ILibUnaligned_Read32(tmp);
 		}
-		
+
 		if (Key2Len > 4)
 		{
-			((int*)tmp)[0] = 0;
+			ILibUnaligned_Write32(tmp, 0);
 			for (i = 0; i < 4; ++i)
 			{
 				tmp[i] = Key2[Key2Len - 1 - i];
 			}
-			retVal ^= ((int*)tmp)[0];
-			
+			retVal ^= (int)ILibUnaligned_Read32(tmp);
+
 			if (Key2Len > 12)
 			{
 				int x = Key2Len / 2;
-				((int*)tmp)[0] = 0;
+				ILibUnaligned_Write32(tmp, 0);
 				for (i = 0; i < 4; ++i)
 				{
 					tmp[i] = Key2[i + x];
 				}
-				retVal ^= ((int*)tmp)[0];
+				retVal ^= (int)ILibUnaligned_Read32(tmp);
 			}
 		}
 	}

--- a/microstack/ILibParsers.h
+++ b/microstack/ILibParsers.h
@@ -173,6 +173,16 @@ void ILibDispatchSemaphore_post(sem_t* s);
 #include<stdint.h>
 static inline void ignore_result(uintptr_t result) { (void)result; }
 
+// Alignment-safe scalar access. Strict-alignment CPUs (MIPS, ARMv5/v6, RISC-V, SPARC) raise
+// SIGBUS when a 16/32/64 bit load or store is issued against an unaligned address, so any wide
+// access into a byte buffer at a runtime offset must go through these instead of a pointer cast.
+static inline uint16_t ILibUnaligned_Read16(const void *src) { uint16_t v; memcpy(&v, src, sizeof(v)); return(v); }
+static inline uint32_t ILibUnaligned_Read32(const void *src) { uint32_t v; memcpy(&v, src, sizeof(v)); return(v); }
+static inline uint64_t ILibUnaligned_Read64(const void *src) { uint64_t v; memcpy(&v, src, sizeof(v)); return(v); }
+static inline void ILibUnaligned_Write16(void *dst, uint16_t v) { memcpy(dst, &v, sizeof(v)); }
+static inline void ILibUnaligned_Write32(void *dst, uint32_t v) { memcpy(dst, &v, sizeof(v)); }
+static inline void ILibUnaligned_Write64(void *dst, uint64_t v) { memcpy(dst, &v, sizeof(v)); }
+
 #if defined(_DEBUG)
 #define PRINTERROR() printf("ERROR in %s, line %d\r\n", __FILE__, __LINE__);
 #else
@@ -463,13 +473,16 @@ int ILibIsRunningOnChainThread(void* chain);
 
 	#define ILibChain_Link_SetMetadata(chainLink, value) if((chainLink)!=NULL) { ILibMemory_Free(((ILibChain_Link*)chainLink)->MetaData); ((ILibChain_Link*)chainLink)->MetaData = value; }
 	#define ILibChain_Link_GetMetadata(chainLink) ((chainLink)==NULL?"":(((ILibChain_Link*)chainLink)->MetaData))
-	#define ILibMemory_Canary (((int*)((char*)(const char*)"broe"))[0])
+	#define ILibMemory_Canary ((int)ILibUnaligned_Read32("broe"))
 	#define ILibMemory_RawPtr(ptr) ((char*)(ptr) - sizeof(ILibMemory_Header))
 	#define ILibMemory_RawSize(ptr) (ILibMemory_Size((ptr)) + ILibMemory_ExtraSize((ptr)) + sizeof(ILibMemory_Header))
 	#define ILibMemory_MemType(ptr) (((ILibMemory_Header*)ILibMemory_RawPtr((ptr)))->memoryType)
 	#define ILibMemory_Size(ptr) (((ILibMemory_Header*)ILibMemory_RawPtr((ptr)))->size)
 	#define ILibMemory_ExtraSize(ptr) (((ILibMemory_Header*)ILibMemory_RawPtr((ptr)))->extraSize)
-	#define ILibMemory_Ex_CanaryOK(ptr) ((ptr)==NULL?0:((((ILibMemory_Header*)ILibMemory_RawPtr((ptr)))->CANARY) == ILibMemory_Canary))
+	// The canary is probed against pointers that may not be ILibMemory blocks at all (duktape
+	// buffers, list nodes). Every real one is malloc/alloca + sizeof(ILibMemory_Header), so a
+	// misaligned candidate can be rejected outright rather than faulted on (SIGBUS on MIPS).
+	#define ILibMemory_Ex_CanaryOK(ptr) (((ptr)==NULL || ((((uintptr_t)(ptr)) & (sizeof(void*) - 1)) != 0))?0:((((ILibMemory_Header*)ILibMemory_RawPtr((ptr)))->CANARY) == ILibMemory_Canary))
 #ifdef WIN32
 	int ILibMemory_CanaryOK(void *ptr);
 #else

--- a/microstack/ILibRemoteLogging.c
+++ b/microstack/ILibRemoteLogging.c
@@ -635,8 +635,8 @@ void ILibRemoteLogging_FileTransport_CommandSink(ILibRemoteLogging sender, ILibR
 			{
 				if (dataLen == 4 && ft->logFile != NULL)
 				{
-					unsigned short newModules = ntohs(((unsigned short*)data)[0]);
-					unsigned short newFlags = ntohs(((unsigned short*)data)[1]);
+					unsigned short newModules = ntohs(ILibUnaligned_Read16(data));
+					unsigned short newFlags = ntohs(ILibUnaligned_Read16((char*)data + 2));
 					obj->Sessions[i].Flags = (newFlags & 0x3F) << 16;
 					obj->Sessions[i].Flags |= (unsigned int)newModules;
 

--- a/microstack/ILibRemoteLogging.h
+++ b/microstack/ILibRemoteLogging.h
@@ -78,8 +78,8 @@ char* ILibRemoteLogging_ConvertAddress(struct sockaddr* addr);
 	void ILibRemoteLogging_DeleteUserContext(ILibRemoteLogging logger, void *userContext);
 	void ILibRemoteLogging_RegisterCommandSink(ILibRemoteLogging logger, ILibRemoteLogging_Modules module, ILibRemoteLogging_OnCommand sink);
 	int ILibRemoteLogging_Dispatch(ILibRemoteLogging loggingModule, char* data, int dataLen, void *userContext);
-	#define ILibRemoteLogging_ReadModuleType(data) ((ILibRemoteLogging_Modules)ntohs(((unsigned short*)data)[0]))
-	#define ILibRemoteLogging_ReadFlags(data) ((ILibRemoteLogging_Flags)ntohs(((unsigned short*)data)[1]))
+	#define ILibRemoteLogging_ReadModuleType(data) ((ILibRemoteLogging_Modules)ntohs(ILibUnaligned_Read16((char*)(data))))
+	#define ILibRemoteLogging_ReadFlags(data) ((ILibRemoteLogging_Flags)ntohs(ILibUnaligned_Read16(((char*)(data)) + 2)))
 	int ILibRemoteLogging_IsModuleSet(ILibRemoteLogging loggingModule, ILibRemoteLogging_Modules module);
 	void ILibRemoteLogging_Forward(ILibRemoteLogging loggingModule, char* data, int dataLen);
 #else

--- a/microstack/ILibSimpleDataStore.c
+++ b/microstack/ILibSimpleDataStore.c
@@ -69,7 +69,8 @@ Variable	- Key
 Variable	- Value
 ------------------------------------------ */
 
-#define ILibSimpleDataStore_RecordHeader_ValueOffset(h) (((uint64_t*)(((char*)h) - sizeof(uint64_t)))[0])
+#define ILibSimpleDataStore_RecordHeader_ValueOffset(h) ILibUnaligned_Read64(((char*)(h)) - sizeof(uint64_t))
+#define ILibSimpleDataStore_RecordHeader_SetValueOffset(h, v) ILibUnaligned_Write64(((char*)(h)) - sizeof(uint64_t), (v))
 
 #pragma pack(push, 1)
 typedef struct ILibSimpleDataStore_RecordHeader_NG
@@ -132,7 +133,7 @@ void ILibSimpleDataStore_CachedEx(ILibSimpleDataStore dataStore, char* key, size
 		// This is a compresed entry
 		char *tmpkey = (char*)ILibMemory_SmartAllocate(keyLen + sizeof(uint32_t));
 		memcpy_s(tmpkey, ILibMemory_Size(tmpkey), key, keyLen);
-		((uint32_t*)(tmpkey + keyLen))[0] = crc32c(0, (unsigned char*)key, (uint32_t)keyLen);
+		ILibUnaligned_Write32(tmpkey + keyLen, crc32c(0, (unsigned char*)key, (uint32_t)keyLen));
 		key = tmpkey;
 		keyLen = (int)ILibMemory_Size(key);
 	}
@@ -192,7 +193,7 @@ void ILibSimpleDataStore_Cached_GetValues_sink(ILibHashtable sender, void *Key1,
 	// check if this is a compressed record
 	if (Key2Len > sizeof(uint32_t))
 	{
-		if (((uint32_t*)(Key2 + Key2Len - sizeof(uint32_t)))[0] == crc32c(0, (unsigned char*)Key2, Key2Len - sizeof(uint32_t)))
+		if (ILibUnaligned_Read32(Key2 + Key2Len - sizeof(uint32_t)) == crc32c(0, (unsigned char*)Key2, Key2Len - sizeof(uint32_t)))
 		{
 			Key2Len -= sizeof(uint32_t);
 			ILibInflate(entry->value, entry->valueLength, NULL, &tmpbufferLen, 0);
@@ -308,7 +309,7 @@ ILibSimpleDataStore_RecordHeader_NG* ILibSimpleDataStore_ReadNextRecord(ILibSimp
 	node->nodeSize = (int)ntohl(node->nodeSize);
 	node->keyLen = (int)ntohl(node->keyLen);
 	node->valueLength = (int)ntohl(node->valueLength);
-	ILibSimpleDataStore_RecordHeader_ValueOffset(node) = (uint64_t)((uint64_t)ILibSimpleDataStore_GetPosition(root->dataFile) + (uint64_t)node->keyLen);
+	ILibSimpleDataStore_RecordHeader_SetValueOffset(node, (uint64_t)((uint64_t)ILibSimpleDataStore_GetPosition(root->dataFile) + (uint64_t)node->keyLen));
 
 	if (node->keyLen > (int)((sizeof(ILibScratchPad) - nodeSize - sizeof(uint64_t))))
 	{
@@ -345,7 +346,7 @@ ILibSimpleDataStore_RecordHeader_NG* ILibSimpleDataStore_ReadNextRecord(ILibSimp
 		// Before we assume this is a bad hash check, we need to verify it's not a compressed node
 		if (node->keyLen > sizeof(uint32_t))
 		{
-			if (crc32c(0, (unsigned char*)node->key, node->keyLen - sizeof(uint32_t)) == ((uint32_t*)(node->key + node->keyLen - sizeof(uint32_t)))[0])
+			if (crc32c(0, (unsigned char*)node->key, node->keyLen - sizeof(uint32_t)) == ILibUnaligned_Read32(node->key + node->keyLen - sizeof(uint32_t)))
 			{
 				return(node);
 			}
@@ -676,7 +677,7 @@ __EXPORT_TYPE int ILibSimpleDataStore_PutEx2(ILibSimpleDataStore dataStore, char
 		char *tmpkey = (char*)ILibMemory_SmartAllocate(keyLen + sizeof(int));
 		keyAllocated = 1;
 		memcpy_s(tmpkey, ILibMemory_Size(tmpkey), key, keyLen);
-		((uint32_t*)(tmpkey + keyLen))[0] = crc32c(0, (unsigned char*)tmpkey, (uint32_t)keyLen); // No dataloss, capped to INT32_MAX
+		ILibUnaligned_Write32(tmpkey + keyLen, crc32c(0, (unsigned char*)tmpkey, (uint32_t)keyLen)); // No dataloss, capped to INT32_MAX
 		key = tmpkey;
 		keyLen = (int)ILibMemory_Size(key);
 		memcpy_s(hash, sizeof(hash), vhash, SHA384HASHSIZE);
@@ -778,7 +779,7 @@ __EXPORT_TYPE int ILibSimpleDataStore_GetEx(ILibSimpleDataStore dataStore, char*
 			size_t tmplen = 0;
 			char *tmpkey = (char*)ILibMemory_SmartAllocate(keyLen + sizeof(uint32_t));
 			memcpy_s(tmpkey, ILibMemory_Size(tmpkey), key, keyLen);
-			((uint32_t*)(tmpkey + keyLen))[0] = crc32c(0, (unsigned char*)key, (uint32_t)keyLen); // No dataloss, capped to INT32_MAX
+			ILibUnaligned_Write32(tmpkey + keyLen, crc32c(0, (unsigned char*)key, (uint32_t)keyLen)); // No dataloss, capped to INT32_MAX
 			centry = (ILibSimpleDataStore_CacheEntry*)ILibHashtable_Get(root->cacheTable, NULL, tmpkey, (int)ILibMemory_Size(tmpkey));
 			if (centry != NULL)
 			{
@@ -817,7 +818,7 @@ __EXPORT_TYPE int ILibSimpleDataStore_GetEx(ILibSimpleDataStore dataStore, char*
 		// Before returning an error, check if this is a compressed record
 		char *tmpkey = (char*)ILibMemory_SmartAllocate(keyLen + sizeof(uint32_t));
 		memcpy_s(tmpkey, ILibMemory_Size(tmpkey), key, keyLen);
-		((uint32_t*)(tmpkey + keyLen))[0] = crc32c(0, (unsigned char*)tmpkey, (uint32_t)keyLen); // no dataloss, capped to INT32_MAX
+		ILibUnaligned_Write32(tmpkey + keyLen, crc32c(0, (unsigned char*)tmpkey, (uint32_t)keyLen)); // no dataloss, capped to INT32_MAX
 		entry = (ILibSimpleDataStore_TableEntry*)ILibHashtable_Get(root->keyTable, NULL, tmpkey, (int)ILibMemory_Size(tmpkey));
 		ILibMemory_Free(tmpkey);
 		if (entry != NULL) { isCompressed = 1; }
@@ -881,7 +882,7 @@ __EXPORT_TYPE char* ILibSimpleDataStore_GetHashEx(ILibSimpleDataStore dataStore,
 			// Let's check if this is a compressed record entry
 			char *tmpkey = (char*)ILibMemory_SmartAllocate(keyLen + sizeof(uint32_t));
 			memcpy_s(tmpkey, ILibMemory_Size(tmpkey), key, keyLen);
-			((uint32_t*)(tmpkey + keyLen))[0] = crc32c(0, (unsigned char*)key, (uint32_t)keyLen); // no dataloss, capped to INT32_MAX
+			ILibUnaligned_Write32(tmpkey + keyLen, crc32c(0, (unsigned char*)key, (uint32_t)keyLen)); // no dataloss, capped to INT32_MAX
 			centry = (ILibSimpleDataStore_CacheEntry*)ILibHashtable_Get(root->cacheTable, NULL, tmpkey, (int)ILibMemory_Size(tmpkey));
 			ILibMemory_Free(tmpkey);
 			if (centry != NULL)
@@ -901,7 +902,7 @@ __EXPORT_TYPE char* ILibSimpleDataStore_GetHashEx(ILibSimpleDataStore dataStore,
 		// Before we return an error, let's check if this is a compressed record
 		char* tmpkey = (char*)ILibMemory_SmartAllocate(keyLen + sizeof(uint32_t));
 		memcpy_s(tmpkey, ILibMemory_Size(tmpkey), key, keyLen);
-		((uint32_t*)(tmpkey + keyLen))[0] = crc32c(0, (unsigned char*)key, (uint32_t)keyLen);
+		ILibUnaligned_Write32(tmpkey + keyLen, crc32c(0, (unsigned char*)key, (uint32_t)keyLen));
 		entry = (ILibSimpleDataStore_TableEntry*)ILibHashtable_Get(root->keyTable, NULL, tmpkey, (int)ILibMemory_Size(tmpkey));
 		ILibMemory_Free(tmpkey);
 	}
@@ -928,7 +929,7 @@ __EXPORT_TYPE int ILibSimpleDataStore_DeleteEx(ILibSimpleDataStore dataStore, ch
 		// Check to see if this is a compressed record, before we return an error
 		char *tmpkey = (char*)ILibMemory_SmartAllocate(keyLen + sizeof(uint32_t));
 		memcpy_s(tmpkey, ILibMemory_Size(tmpkey), key, keyLen);
-		((uint32_t*)(tmpkey + keyLen))[0] = crc32c(0, (unsigned char*)key, (uint32_t)keyLen); // no dataloss, capped to INT32_MAX
+		ILibUnaligned_Write32(tmpkey + keyLen, crc32c(0, (unsigned char*)key, (uint32_t)keyLen)); // no dataloss, capped to INT32_MAX
 		entry = (ILibSimpleDataStore_TableEntry*)ILibHashtable_Remove(root->keyTable, NULL, tmpkey, (int)ILibMemory_Size(tmpkey));
 		if (entry != NULL)
 		{
@@ -1036,7 +1037,7 @@ void ILibSimpleDataStore_EnumerateKeysSink(ILibHashtable sender, void *Key1, cha
 	if (Key2Len > sizeof(uint32_t))
 	{
 		// Check if this is a compressed entry
-		if (crc32c(0, (unsigned char*)Key2, Key2Len - sizeof(uint32_t)) == ((uint32_t*)(Key2 + Key2Len - sizeof(uint32_t)))[0])
+		if (crc32c(0, (unsigned char*)Key2, Key2Len - sizeof(uint32_t)) == ILibUnaligned_Read32(Key2 + Key2Len - sizeof(uint32_t)))
 		{
 			Key2Len -= sizeof(uint32_t);
 		}

--- a/microstack/ILibWebClient.c
+++ b/microstack/ILibWebClient.c
@@ -1229,7 +1229,7 @@ ILibAsyncSocket_SendStatus ILibWebClient_WebSocket_Send(ILibWebClient_StateObjec
 	char dataFrame[WEBSOCKET_MAX_OUTPUT_FRAMESIZE];
 	char header[10];
 	char maskKey[4];
-	int maskKeyInt;
+	uint32_t maskKeyInt;
 	int headerLen;
 	unsigned short flags = WEBSOCKET_MASK;
 	ILibAsyncSocket_SendStatus RetVal = ILibAsyncSocket_SEND_ON_CLOSED_SOCKET_ERROR;
@@ -1287,10 +1287,10 @@ ILibAsyncSocket_SendStatus ILibWebClient_WebSocket_Send(ILibWebClient_StateObjec
 		{
 			// Mask the payload
 			util_random(4, maskKey);
-			maskKeyInt = ((int*)maskKey)[0];
+			maskKeyInt = ILibUnaligned_Read32(maskKey);
 			if (bufferLen > 0) {
 				int x;
-				for (x = 0; x < (bufferLen >> 2); ++x) { ((int*)dataFrame)[x] = ((int*)buffer)[x] ^ (int)maskKeyInt; } // Mask 4 bytes at a time
+				for (x = 0; x < (bufferLen >> 2); ++x) { ILibUnaligned_Write32(dataFrame + (x << 2), ILibUnaligned_Read32(buffer + (x << 2)) ^ maskKeyInt); } // Mask 4 bytes at a time
 				for (x = (x << 2); x < bufferLen; ++x) { dataFrame[x] = buffer[x] ^ maskKey[x % 4]; } // Mask the reminder
 				//for (x = 0; x < bufferLen; ++x) { dataFrame[x] = buffer[x] ^ maskKey[x % 4]; } // This is the slower version
 			}
@@ -1342,7 +1342,7 @@ int ILibWebClient_ProcessWebSocketData(char* buffer, int offset, int length, ILi
 	if (length < 2) { return(offset); } // We need at least 2 bytes to read enough of the headers to know how long the frame is
 	state = (ILibWebClient_WebSocketState*)wr->Buffer[0];
 
-	hdr = ntohs(((unsigned short*)(buffer + offset))[0]);
+	hdr = ntohs(ILibUnaligned_Read16(buffer + offset));
 	FIN = (hdr & WEBSOCKET_FIN) != 0;
 	OPCODE = (hdr & WEBSOCKET_OPCODE) >> 8;
 
@@ -1350,7 +1350,7 @@ int ILibWebClient_ProcessWebSocketData(char* buffer, int offset, int length, ILi
 	if (plen == 126)
 	{
 		if (length < 4) { return(offset); } // We need at least 4 bytes to read enough of the headers
-		plen = (unsigned short)ntohs(((unsigned short*)(buffer + offset))[1]);
+		plen = (unsigned short)ntohs(ILibUnaligned_Read16(buffer + offset + 2));
 		i += 2;
 	}
 	else if (plen == 127)

--- a/microstack/ILibWebRTC.c
+++ b/microstack/ILibWebRTC.c
@@ -1510,7 +1510,7 @@ int ILibStun_WebRTC_UpdateOfferResponse(struct ILibStun_IceState *iceState, char
 
 	if ((*answer = (char*)malloc(rlen + turnRecordSize)) == NULL) ILIBCRITICALEXIT(254);
 	((unsigned short*)(*answer))[0] = 1; // Block version number
-	((unsigned int*)(*answer + 2))[0] = htonl(BlockFlags); // Block flags
+	ILibUnaligned_Write32(*answer + 2, htonl(BlockFlags)); // Block flags
 	memcpy_s(*answer + 6, rlen + turnRecordSize - 6, iceState->userAndKey, 42);
 
 	(*answer)[48] = (char)(iceState->parentStunModule->CertThumbprintLength);
@@ -1518,8 +1518,8 @@ int ILibStun_WebRTC_UpdateOfferResponse(struct ILibStun_IceState *iceState, char
 	(*answer)[49 + 32] = (char)LocalInterfaceListV4Len;
 	for (i = 0; i < LocalInterfaceListV4Len; i++)
 	{
-		((int*)(*answer + 49 + 33 + (i * 6)))[0] = LocalInterfaceListV4[i].sin_addr.s_addr;
-		((short*)(*answer + 49 + 33 + (i * 6) + 4))[0] = ((struct sockaddr_in*)(&(iceState->parentStunModule->LocalIf)))->sin_port;
+		ILibUnaligned_Write32(*answer + 49 + 33 + (i * 6), (uint32_t)LocalInterfaceListV4[i].sin_addr.s_addr);
+		ILibUnaligned_Write16(*answer + 49 + 33 + (i * 6) + 4, (uint16_t)((struct sockaddr_in*)(&(iceState->parentStunModule->LocalIf)))->sin_port);
 	}
 	if (LocalInterfaceListV4 != NULL) free(LocalInterfaceListV4);
 	if (turnRecordSize > 0)
@@ -2868,7 +2868,7 @@ int ILibStun_SetIceOffer2(void *StunModule, char* iceOffer, int iceOfferLen, cha
 	memcpy_s(state->offerblock, iceOfferLen + candidateCount + 1, iceOffer, iceOfferLen);
 	memset(state->offerblock + iceOfferLen, 0, candidateCount + 1);
 	state->blockversion = ntohs(((unsigned short*)(state->offerblock))[0]);
-	state->blockflags = ntohl(((unsigned int*)(state->offerblock + 2))[0]);
+	state->blockflags = ntohl(ILibUnaligned_Read32(state->offerblock + 2));
 	state->rusernamelen = state->offerblock[6];
 	state->rusername = state->offerblock + 7;
 	state->rkeylen = state->offerblock[7 + state->rusernamelen];
@@ -3136,14 +3136,15 @@ ILibTransport_DoneState ILibStun_SendSctpPacket(struct ILibStun_Module *obj, int
 {
 	if (bufferLength < 12) return ILibTransport_DoneState_ERROR;
 
-	// Setup the header
-	((unsigned short*)buffer)[0] = htons(obj->dTlsSessions[session]->inport);		// Source port
-	((unsigned short*)buffer)[1] = htons(obj->dTlsSessions[session]->outport);		// Destination port
-	((unsigned int*)buffer)[1] = obj->dTlsSessions[session]->tag;					// Tag
+	// Setup the header. Callers pass rpacket->Data - 12, which is 2 mod 4 (packed struct), so
+	// the 32 bit header fields must not be stored through pointer casts.
+	ILibUnaligned_Write16(buffer, htons(obj->dTlsSessions[session]->inport));		// Source port
+	ILibUnaligned_Write16(buffer + 2, htons(obj->dTlsSessions[session]->outport));	// Destination port
+	ILibUnaligned_Write32(buffer + 4, obj->dTlsSessions[session]->tag);				// Tag
 
 	// Compute and put the CRC at the right place
-	((unsigned int*)buffer)[2] = 0;
-	((unsigned int*)buffer)[2] = crc32c(0, (unsigned char*)buffer, (uint32_t)bufferLength);
+	ILibUnaligned_Write32(buffer + 8, 0);
+	ILibUnaligned_Write32(buffer + 8, crc32c(0, (unsigned char*)buffer, (uint32_t)bufferLength));
 
 	ILibRemoteLogging_printf(ILibChainGetLogger(obj->ChainLink.ParentChain), ILibRemoteLogging_Modules_WebRTC_SCTP, ILibRemoteLogging_Flags_VerbosityLevel_4, "SCTP[%d] (%d): Send", session, bufferLength);
 	
@@ -3164,9 +3165,9 @@ ILibTransport_DoneState ILibStun_SendSctpPacket(struct ILibStun_Module *obj, int
 		}
 		if ((buffer + i)[0] == 0)
 		{
-			ILibRemoteLogging_printf(ILibChainGetLogger(obj->ChainLink.ParentChain), ILibRemoteLogging_Modules_WebRTC_SCTP, ILibRemoteLogging_Flags_VerbosityLevel_4, "... TSN: %u", ntohl(((ILibSCTP_DataPayload*)(buffer + i))->TSN));
+			ILibRemoteLogging_printf(ILibChainGetLogger(obj->ChainLink.ParentChain), ILibRemoteLogging_Modules_WebRTC_SCTP, ILibRemoteLogging_Flags_VerbosityLevel_4, "... TSN: %u", ntohl(ILibUnaligned_Read32(buffer + i + 4)));
 		}
-		utmp = ntohs(((uint16_t*)(buffer + i))[1]);
+		utmp = ntohs(ILibUnaligned_Read16(buffer + i + 2));
 		i += utmp;
 
 		if (utmp == 0) 
@@ -3178,7 +3179,7 @@ ILibTransport_DoneState ILibStun_SendSctpPacket(struct ILibStun_Module *obj, int
 
 	ILibRemoteLogging_printf(ILibChainGetLogger(obj->ChainLink.ParentChain), ILibRemoteLogging_Modules_WebRTC_SCTP, ILibRemoteLogging_Flags_VerbosityLevel_5, "... Source: %u , Destination: %u", obj->dTlsSessions[session]->inport, obj->dTlsSessions[session]->outport);
 	ILibRemoteLogging_printf(ILibChainGetLogger(obj->ChainLink.ParentChain), ILibRemoteLogging_Modules_WebRTC_SCTP, ILibRemoteLogging_Flags_VerbosityLevel_5, "... TAG: %u", obj->dTlsSessions[session]->tag);
-	ILibRemoteLogging_printf(ILibChainGetLogger(obj->ChainLink.ParentChain), ILibRemoteLogging_Modules_WebRTC_SCTP, ILibRemoteLogging_Flags_VerbosityLevel_5, "... Checksum: %u", ((unsigned int*)buffer)[2]);
+	ILibRemoteLogging_printf(ILibChainGetLogger(obj->ChainLink.ParentChain), ILibRemoteLogging_Modules_WebRTC_SCTP, ILibRemoteLogging_Flags_VerbosityLevel_5, "... Checksum: %u", ILibUnaligned_Read32(buffer + 8));
 
 #ifdef _REMOTELOGGING
 	ILibSctp_DebugSctpPacket(ILibChainGetLogger(obj->ChainLink.ParentChain), buffer, bufferLength, "ILibStun_SendSctpPacket");
@@ -3666,7 +3667,7 @@ void ILibStun_SctpProcessStreamData(struct ILibStun_Module *obj, int session, un
 		unsigned short offset = ((ILibSCTP_PendingTSN_Data*)((char*)&o->pendingReconfigPacket))->Data.StreamIdOffset;
 		int streamIdCount = (offset / 2) - 2;
 
-		if(((unsigned int*)(o->rpacket + o->rpacketsize - offset))[0] <= o->userTSN)
+		if(ILibUnaligned_Read32(o->rpacket + o->rpacketsize - offset) <= o->userTSN)
 		{
 			// The LastTSN specified by the peer has passed, so we can continue with the ChannelClose operation
 			// Let's locally initiate a ChannelClose... We'll propagate the close in the response handler
@@ -4014,7 +4015,7 @@ void ILibStun_SctpResent(struct ILibStun_dTlsSession *obj)
 					ILibStun_SendSctpPacket(obj->parent, obj->sessionId, rpacket->Data - 12, rpacket->PacketSize);
 #ifdef _WEBRTCDEBUG
 					//if (obj->onSendRetry != NULL) { obj->onSendRetry(obj, "OnSendRetry", ((unsigned short*)(rpacket->Data + sizeof(char*)))[0]); }
-					if (obj->onSendRetry != NULL) { obj->onSendRetry(obj, "OnSendRetry", ntohl(((unsigned int*)rpacket->Data)[1])); }
+					if (obj->onSendRetry != NULL) { obj->onSendRetry(obj, "OnSendRetry", ntohl(ILibUnaligned_Read32(rpacket->Data + 4))); }
 					if (obj->onRetryPacket != NULL)
 					{
 						char *tmp = ILibMemory_AllocateA(rpacket->PacketSize + 14);
@@ -4532,7 +4533,7 @@ void ILibStun_ProcessSctpPacket(struct ILibStun_Module *obj, int session, char* 
 											pending.Data.StreamIdOffset = (4 + (2*streamCount));
 
 											// We are going to store the TSN followed by the StreamIds 
-											((int*)(o->rpacket + o->rpacketsize - pending.Data.StreamIdOffset))[0] = lastTSN;
+											ILibUnaligned_Write32(o->rpacket + o->rpacketsize - pending.Data.StreamIdOffset, (uint32_t)lastTSN);
 											for(i = 0; i < streamCount; ++i)
 											{
 												((unsigned short*)(o->rpacket + o->rpacketsize - pending.Data.StreamIdOffset))[i+2] = ntohs(req->Streams[i]);
@@ -5205,7 +5206,7 @@ void ILibStun_ProcessSctpPacket(struct ILibStun_Module *obj, int session, char* 
 			ILibStun_SctpDisconnect(obj, session);
 			return;
 		case RCTP_CHUNK_TYPE_COOKIEECHO:
-			o->SRTT = (int)(ILibGetUptime() - *((long long*)(buffer + ptr + 4)));
+			o->SRTT = (int)(ILibGetUptime() - (long long)ILibUnaligned_Read64(buffer + ptr + 4));
 			o->RTTVAR = o->SRTT / 2;
 			o->RTO = o->SRTT + 4 * o->RTTVAR;
 			o->SSTHRESH = 4 * ILibRUDP_StartMTU;
@@ -6689,7 +6690,7 @@ void ILibTURN_ProcessChannelData(struct ILibTURN_TurnClientObject *turn, unsigne
 STUN_TYPE ILibTURN_GetMethodType(char* buffer, int offset, int length)
 {
 	UNREFERENCED_PARAMETER(length);
-	return ((STUN_TYPE)ntohs(((unsigned short*)(buffer + offset))[0]));
+	return ((STUN_TYPE)ntohs(ILibUnaligned_Read16(buffer + offset)));
 }
 
 char* ILibTURN_GetTransactionID(char* buffer, int offset, int length)
@@ -6717,7 +6718,7 @@ char* ILibTURN_GetErrorReason(char* buffer, int length)
 
 int ILibTURN_GetAttributeValue(char* buffer, int offset, int length, STUN_ATTRIBUTES attribute, int index, char** value)
 {
-	unsigned short messageLength = 20 + ntohs(((unsigned short*)(buffer + offset))[1]);
+	unsigned short messageLength = 20 + ntohs(ILibUnaligned_Read16(buffer + offset + 2));
 	int i = 0;
 
 	UNREFERENCED_PARAMETER(length);
@@ -6725,8 +6726,8 @@ int ILibTURN_GetAttributeValue(char* buffer, int offset, int length, STUN_ATTRIB
 	offset += 20;
 	while (offset + 4 <= messageLength)												// Decode each attribute one at a time
 	{
-		STUN_ATTRIBUTES current = (STUN_ATTRIBUTES)ntohs(((unsigned short*)(buffer + offset))[0]);
-		int attrLength = ntohs(((unsigned short*)(buffer + offset))[1]);
+		STUN_ATTRIBUTES current = (STUN_ATTRIBUTES)ntohs(ILibUnaligned_Read16(buffer + offset));
+		int attrLength = ntohs(ILibUnaligned_Read16(buffer + offset + 2));
 		if (offset + 4 + attrLength > messageLength) return 0;
 
 		if (attribute == current)
@@ -6752,7 +6753,7 @@ int ILibTURN_GetAttributeStartLocation(char *buffer, int offset, int length, STU
 
 int ILibTURN_GetAttributeCount(char* buffer, int offset, int length, STUN_ATTRIBUTES attribute)
 {
-	unsigned short messageLength = 20 + ntohs(((unsigned short*)(buffer + offset))[1]);
+	unsigned short messageLength = 20 + ntohs(ILibUnaligned_Read16(buffer + offset + 2));
 	int retVal = 0;
 
 	UNREFERENCED_PARAMETER(length);
@@ -6760,8 +6761,8 @@ int ILibTURN_GetAttributeCount(char* buffer, int offset, int length, STUN_ATTRIB
 	offset += 20;
 	while (offset + 4 <= messageLength)												// Decode each attribute one at a time
 	{
-		STUN_ATTRIBUTES current = (STUN_ATTRIBUTES)ntohs(((unsigned short*)(buffer + offset))[0]);
-		int attrLength = ntohs(((unsigned short*)(buffer + offset))[1]);
+		STUN_ATTRIBUTES current = (STUN_ATTRIBUTES)ntohs(ILibUnaligned_Read16(buffer + offset));
+		int attrLength = ntohs(ILibUnaligned_Read16(buffer + offset + 2));
 		if (offset + 4 + attrLength > messageLength) return 0;
 
 		if (attribute == current) { ++retVal; }
@@ -6816,7 +6817,7 @@ int ILibTURN_IsPacketAuthenticated(struct ILibTURN_TurnClientObject *turn, char*
 	if (fingerprintLen > 0)
 	{
 		fingerprintIndex = ILibTURN_GetAttributeValue(buffer, offset, length, STUN_ATTRIB_FINGERPRINT, 0, NULL);
-		actual = 0x5354554e ^ ntohl(((unsigned int*)fingerprint)[0]);
+		actual = 0x5354554e ^ ntohl(ILibUnaligned_Read32(fingerprint));
 		calculated = ILibStun_CRC32(buffer + offset, fingerprintIndex);
 		if (calculated != actual) { return 0; }
 	}
@@ -6824,15 +6825,15 @@ int ILibTURN_IsPacketAuthenticated(struct ILibTURN_TurnClientObject *turn, char*
 	// Fix Length if there is a fingerprint
 	if (fingerprintLen > 0)
 	{
-		tempVal = ntohs(((unsigned short*)(buffer + offset))[1]);
-		((unsigned short*)(buffer + offset))[1] = htons(tempVal - 8);
+		tempVal = ntohs(ILibUnaligned_Read16(buffer + offset + 2));
+		ILibUnaligned_Write16(buffer + offset + 2, htons(tempVal - 8));
 	}
 
 	ILibTURN_GenerateIntegrityKey(turn->username, turn->currentRealm, turn->password, integrityKey);
 	ILibTURN_CalculateMessageIntegrity(buffer, offset, MessageIntegrityPtr, integrityKey, 16, integrity);
 
 	// Put Length Back if we had to adjust the value due to fingerprint
-	if (fingerprintLen > 0) { ((unsigned short*)(buffer + offset))[1] = htons(tempVal); }
+	if (fingerprintLen > 0) { ILibUnaligned_Write16(buffer + offset + 2, htons(tempVal)); }
 
 	if (MessageIntegrityValueLen == 20 && memcmp(MessageIntegrityValue, integrity, 20) == 0) { return 1; }
 
@@ -7098,8 +7099,8 @@ void ILibTURN_ProcessStunFormattedPacket(struct ILibTURN_TurnClientObject *turn,
 
 int ILibTURN_GetStunPacketLength(char* buffer, int offset, int length)
 {
-	unsigned short messageLength = 20 + ntohs(((unsigned short*)(buffer + offset))[1]);
-	int magic = ntohl(((unsigned int*)(buffer + offset))[1]);
+	unsigned short messageLength = 20 + ntohs(ILibUnaligned_Read16(buffer + offset + 2));
+	int magic = ntohl(ILibUnaligned_Read32(buffer + offset + 4));
 	if (messageLength > length || magic != 0x2112A442) // Check the length and magic string
 	{
 		return 0;
@@ -7117,11 +7118,11 @@ void ILibTURN_TCP_OnData(ILibAsyncSocket_SocketModule socketModule, char* buffer
 
 	if (endPointer >= 4)
 	{
-		if (ntohs(((unsigned short*)(buffer + *p_beginPointer))[0]) >> 14 == 1)
+		if (ntohs(ILibUnaligned_Read16(buffer + *p_beginPointer)) >> 14 == 1)
 		{
 			// This is Channel Data
-			unsigned short ChannelNumber = (unsigned short)((int)ntohs(((unsigned short*)(buffer + *p_beginPointer))[0]) ^ (int)0x4000);
-			unsigned short ChannelDataLength = ntohs(((unsigned short*)(buffer + *p_beginPointer))[1]);
+			unsigned short ChannelNumber = (unsigned short)((int)ntohs(ILibUnaligned_Read16(buffer + *p_beginPointer)) ^ (int)0x4000);
+			unsigned short ChannelDataLength = ntohs(ILibUnaligned_Read16(buffer + *p_beginPointer + 2));
 			if (endPointer >= (4 + FOURBYTEBOUNDARY(ChannelDataLength)))
 			{
 				ILibTURN_ProcessChannelData(turn, ChannelNumber, buffer, *p_beginPointer + 4, ChannelDataLength);

--- a/microstack/ILibWebServer.c
+++ b/microstack/ILibWebServer.c
@@ -572,7 +572,7 @@ int ILibWebServer_ProcessWebSocketData(struct ILibWebServer_Session *ws, char* b
 
 	if (length < 2) { return(offset); } // We need at least 2 bytes to read enough of the headers to know how long the frame is
 
-	hdr = ntohs(((unsigned short*)(buffer + offset))[0]);
+	hdr = ntohs(ILibUnaligned_Read16(buffer + offset));
 	FIN = (hdr & WEBSOCKET_FIN) != 0;
 	OPCODE = (hdr & WEBSOCKET_OPCODE) >> 8;
 
@@ -580,7 +580,7 @@ int ILibWebServer_ProcessWebSocketData(struct ILibWebServer_Session *ws, char* b
 	if (plen == 126)
 	{
 		if (length < 4) { return(offset); } // We need at least 4 bytes to read enough of the headers
-		plen = (unsigned short)ntohs(((unsigned short*)(buffer + offset))[1]);
+		plen = (unsigned short)ntohs(ILibUnaligned_Read16(buffer + offset + 2));
 		i += 2;
 	}
 	else if (plen == 127)
@@ -591,7 +591,7 @@ int ILibWebServer_ProcessWebSocketData(struct ILibWebServer_Session *ws, char* b
 		} 
 		else
 		{
-			unsigned long long v = ILibNTOHLL(((unsigned long long*)(buffer + offset + 2))[0]);
+			unsigned long long v = ILibNTOHLL(ILibUnaligned_Read64(buffer + offset + 2));
 			if(v > 0x7FFFFFFFUL)
 			{
 				// this value is too big to store in a 32 bit signed variable, so disconnect the websocket.
@@ -1470,21 +1470,21 @@ int ILibWebServer_WebSocket_CreateHeader(char* header, unsigned short FLAGS, uns
 	{
 		retVal = 2;
 		header1 |= payloadLength;
-		((unsigned short*)header)[0] = htons(header1);
+		ILibUnaligned_Write16(header, htons(header1));
 	}
 	else if (payloadLength <= 0xFFFF)
 	{
 		retVal = 4;
 		header1 |= 126;
-		((unsigned short*)header)[0] = htons(header1);
-		((unsigned short*)header)[1] = htons((unsigned short)payloadLength);
+		ILibUnaligned_Write16(header, htons(header1));
+		ILibUnaligned_Write16(header + 2, htons((unsigned short)payloadLength));
 	}
 	else
 	{
 		retVal = 10;
 		header1 |= 127;
-		((unsigned short*)header)[0] = htons(header1);
-		((unsigned long long*)(header + 2))[0] = ILibHTONLL((uint64_t)payloadLength);
+		ILibUnaligned_Write16(header, htons(header1));
+		ILibUnaligned_Write64(header + 2, ILibHTONLL((uint64_t)payloadLength));
 	}
 
 	return retVal;

--- a/microstack/ILibWrapperWebRTC.c
+++ b/microstack/ILibWrapperWebRTC.c
@@ -136,11 +136,11 @@ void ILibWrapper_InitializeDataChannel_Transport(ILibWrapper_WebRTC_DataChannel 
 
 short ILibWrapper_ReadShort(char* buffer, int offset)
 {
-	return(ntohs(((short*)(buffer+offset))[0]));
+	return(ntohs((short)ILibUnaligned_Read16(buffer+offset)));
 }
 int ILibWrapper_ReadInt(char* buffer, int offset)
 {
-	return(ntohl(((int*)(buffer+offset))[0]));
+	return(ntohl((int)ILibUnaligned_Read32(buffer+offset)));
 }
 char* ILibWrapper_ReadString(char* buffer, int offset, int length)
 {
@@ -246,7 +246,7 @@ char* ILibWrapper_SdpToBlock(char* sdp, int sdpLen, int *isActive, char **userna
 					pr3->FirstResult->NextResult->NextResult->NextResult->data[pr3->FirstResult->NextResult->NextResult->NextResult->datalength] = 0;
 					candidateData[3] = (char)ILib_atoi2_int16(pr3->FirstResult->NextResult->NextResult->NextResult->data, pr3->FirstResult->NextResult->NextResult->NextResult->datalength);
 
-					((unsigned short*)candidateData)[2] = htons(port);
+					ILibUnaligned_Write16(candidateData + 4, htons(port));
 					candidateData[6] = 0;
 
 					ILibPushStack(&candidates, candidateData);
@@ -277,10 +277,10 @@ char* ILibWrapper_SdpToBlock(char* sdp, int sdpLen, int *isActive, char **userna
 	retVal = (char*)ILibMemory_SmartAllocateEx(blockLen, sizeof(int));
 	ptr = 0;
 
-	((unsigned short*)(retVal+ptr))[0] = htons(1);
+	ILibUnaligned_Write16(retVal + ptr, htons(1));
 	ptr += 2;
 
-	((unsigned int*)(retVal + ptr))[0] = htonl(BlockFlags);
+	ILibUnaligned_Write32(retVal + ptr, htonl(BlockFlags));
 	ptr += 4;
 
 	(retVal)[ptr] = (char)usernameLen;
@@ -399,18 +399,18 @@ int ILibWrapper_BlockToSDPEx(char* block, int blockLen, char** username, char** 
 
 	util_random(4, junk);
 
-	x = sprintf_s(*sdp, sdpLen, sdpTemplate1, ((unsigned int*)junk)[0]%1000000, *username, *password, dtlshash, isActive==0?"passive":"actpass");
+	x = sprintf_s(*sdp, sdpLen, sdpTemplate1, ILibUnaligned_Read32(junk)%1000000, *username, *password, dtlshash, isActive==0?"passive":"actpass");
 
 	for(c = 1; c <= 2; ++c)
 	{
 		for (i = 0; i < candidatecount; i++)
 		{
 			ptr = i*6;
-			x += sprintf_s(*sdp+x, sdpLen-x, sdpTemplateLocalCand, i, c, 2128609535-i, (unsigned char)candidates[ptr], (unsigned char)candidates[ptr+1], (unsigned char)candidates[ptr+2], (unsigned char)candidates[ptr+3], ntohs(((unsigned short*)(candidates+ptr+4))[0]));
+			x += sprintf_s(*sdp+x, sdpLen-x, sdpTemplateLocalCand, i, c, 2128609535-i, (unsigned char)candidates[ptr], (unsigned char)candidates[ptr+1], (unsigned char)candidates[ptr+2], (unsigned char)candidates[ptr+3], ntohs(ILibUnaligned_Read16(candidates+ptr+4)));
 		}
 		if(serverReflexiveCandidateAddress!=NULL)
 		{
-			x += sprintf_s(*sdp+x, sdpLen-x, sdpTemplateSrflxCand, i, c, 2128609535-i, serverReflexiveCandidateAddress, serverReflexiveCandidatePort, (unsigned char)candidates[0], (unsigned char)candidates[1], (unsigned char)candidates[2], (unsigned char)candidates[3], ntohs(((unsigned short*)(candidates+4))[0]));
+			x += sprintf_s(*sdp+x, sdpLen-x, sdpTemplateSrflxCand, i, c, 2128609535-i, serverReflexiveCandidateAddress, serverReflexiveCandidatePort, (unsigned char)candidates[0], (unsigned char)candidates[1], (unsigned char)candidates[2], (unsigned char)candidates[3], ntohs(ILibUnaligned_Read16(candidates+4)));
 			++i;
 		}
 		if(relayEndPoint!=NULL)


### PR DESCRIPTION
This fixes a.o. datastore access (the local db) on strict-aligment procs like SPARC, MIPS, ARMv5/v6 and RISC-V
Initially found through stress testing the revived MIPS build.

- The agent's datastore marks a compressed record by appending a 32-bit checksum directly after the key bytes.
- The old code wrote and read that checksum by casting a char* at "key + keyLen" to uint32_t* and dereferencing it.
- Whenever the key length is not a multiple of four, that address is misaligned for a 4-byte access.
- x86 and aarch64 silently tolerate misaligned loads and stores, so the bug never showed up on the platforms the agent is usually built and tested on.
- SPARC, MIPS, ARMv5/v6 and RISC-V are strict-alignment CPUs: the hardware raises SIGBUS on such an access, and the agent died on its very first datastore write.

The fix adds small ILibUnaligned_Read/Write16/32/64 helpers to ILibParsers.h that move the value with memcpy instead of a pointer cast.
A memcpy with a constant size never becomes a real function call: on CPUs that tolerate misalignment the compiler turns it into the same single load or store the pointer cast produced, and on strict-alignment CPUs it emits byte-wise instructions that cannot fault. Either way there is no performance cost.
The same pattern is replaced throughout the sourcetree (16 files: datastore CRCs, record value offsets, WebRTC, HTTP, KVM, marshalling, and the memory-canary check), not just the ten datastore places.

Endianness and the on-disk .db format are unchanged, so existing agent databases stay readable.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [x] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [x] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [x] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>

## Testing
All tested on windows 32/64, linux 32/64 and macos x86/arm hardware.
The MIPS and RISCv64 build tested on qemu.

Tested with stresstest script and connectivity test to a meshcentral server being able to use the terminal/files/desktop if available

| Platform (OS / distro / arch) | Tested | Result |
| ----------------------------- | ------ | ------ |
| Windows 11 x86/x64           | ✅     |     ✅   |
| Debian 13 x86/x64  | ✅     |  ✅      |
| RISCv64  | ✅     |   ✅    |
| MIPS  64 musl| ✅     |    ✅    |
| macOS x86/ARM| ✅     |    ✅    |