### PR TITLE
Un-macro ILibMemory_Init_Size and ILibMemory_Size_Validate for MSVC /LTCG issue

### DIFF
--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -1041,11 +1041,11 @@ void* ILibMemory_SmartReAllocate(void *ptr, size_t len)
 {
 	if (ILibMemory_CanaryOK(ptr))
 	{
-		size_t originalRawSize = ILibMemory_Init_Size(ILibMemory_Size(ptr), ILibMemory_ExtraSize(ptr));
+		size_t originalRawSize = ILibMemory_Init_SizeEx(ILibMemory_Size(ptr), ILibMemory_ExtraSize(ptr));
 		size_t originalSize = ILibMemory_Size(ptr);
 		size_t originalExtraSize = ILibMemory_ExtraSize(ptr);
 		if (originalExtraSize) { len = (len + sizeof(void *) - 1) & ~(sizeof(void *) - 1); }
-		size_t newRawSize = ILibMemory_Init_Size(len, originalExtraSize);
+		size_t newRawSize = ILibMemory_Init_SizeEx(len, originalExtraSize);
 
 		if (newRawSize < originalRawSize && originalExtraSize > 0)
 		{

--- a/microstack/ILibParsers.h
+++ b/microstack/ILibParsers.h
@@ -479,11 +479,30 @@ int ILibIsRunningOnChainThread(void* chain);
 	#define ILibMemory_Extra(ptr) (ILibMemory_ExtraSize(ptr)>0?((char*)(ptr) + ILibMemory_Size((ptr)) + sizeof(ILibMemory_Header)):NULL)
 	#define ILibMemory_FromRaw(ptr) ((char*)(ptr) + sizeof(ILibMemory_Header))
 
-	#define ILibMemory_Size_Validate(primaryLen, extraLen) (((size_t)(primaryLen)<(UINT32_MAX - (size_t)(extraLen)))&&((size_t)(extraLen)<(UINT32_MAX-(size_t)(primaryLen)))&&((size_t)((primaryLen) + (extraLen))<(UINT32_MAX - sizeof(ILibMemory_Header)))&&((extraLen)==0 || ((size_t)((primaryLen)+(extraLen)+sizeof(ILibMemory_Header))<(UINT32_MAX-sizeof(ILibMemory_Header)))))
+	// Un-macro'd for the same reason as ILibMemory_Init_SizeEx below: MSVC x86 LTCG miscompiles a conditional built from runtime-sized values when it determines a malloc size.
+	// An oversized length would reach malloc uncaught.
+	static inline int ILibMemory_Size_ValidateEx(size_t primaryLen, size_t extraLen)
+	{
+		if (primaryLen >= (UINT32_MAX - extraLen)) { return(0); }
+		if (extraLen >= (UINT32_MAX - primaryLen)) { return(0); }
+		if ((primaryLen + extraLen) >= (UINT32_MAX - sizeof(ILibMemory_Header))) { return(0); }
+		if (extraLen > 0 && ((primaryLen + extraLen + sizeof(ILibMemory_Header)) >= (UINT32_MAX - sizeof(ILibMemory_Header)))) { return(0); }
+		return(1);
+	}
+	// The macro form stays under this name so code outside this tree that still calls it keeps working.
+	#define ILibMemory_Size_Validate(primaryLen, extraLen) ILibMemory_Size_ValidateEx((size_t)(primaryLen), (size_t)(extraLen))
 	#define ILibMemory_Init_Size(primaryLen, extraLen) (primaryLen + extraLen + sizeof(ILibMemory_Header) + (extraLen>0?sizeof(ILibMemory_Header) + (((primaryLen + sizeof(ILibMemory_Header)) + sizeof(void *) - 1) & ~(sizeof(void *) - 1)):0))
+	// Un-macro'd because with non-constant sizes, MSVC x86 LTCG (v143 and v145, v142 verified unaffected) drops the macro's conditional part (extraLen > 0 ? header + roundup : 0).
+	// So the first block with a non-zero extraLen got 44 bytes instead of 88. This gave a 0xC0000374 (STATUS_HEAP_CORRUPTION) error at startup.
+	static inline size_t ILibMemory_Init_SizeEx(size_t primaryLen, size_t extraLen)
+	{
+		size_t total = primaryLen + extraLen + sizeof(ILibMemory_Header);
+		if (extraLen > 0) { total += sizeof(ILibMemory_Header) + (((primaryLen + sizeof(ILibMemory_Header)) + sizeof(void *) - 1) & ~(sizeof(void *) - 1)); }
+		return(total);
+	}
 	void* ILibMemory_Init(void *ptr, size_t primarySize, size_t extraSize, ILibMemory_Types memType);
-	#define ILibMemory_SmartAllocate(len) ILibMemory_InitEx(ILibMemory_Size_Validate(len,0)?malloc(ILibMemory_Init_Size(len, 0)):NULL, (int)len, 0, ILibMemory_Types_HEAP)
-	#define ILibMemory_SmartAllocateEx(primaryLen, extraLen) ILibMemory_InitEx(ILibMemory_Size_Validate(primaryLen,extraLen)?malloc(ILibMemory_Init_Size(primaryLen, extraLen)):NULL, (int)primaryLen, (int)extraLen, ILibMemory_Types_HEAP)
+	#define ILibMemory_SmartAllocate(len) ILibMemory_InitEx(ILibMemory_Size_ValidateEx((size_t)(len),0)?malloc(ILibMemory_Init_Size(len, 0)):NULL, (int)len, 0, ILibMemory_Types_HEAP)
+	#define ILibMemory_SmartAllocateEx(primaryLen, extraLen) ILibMemory_InitEx(ILibMemory_Size_ValidateEx((size_t)(primaryLen),(size_t)(extraLen))?malloc(ILibMemory_Init_SizeEx((size_t)(primaryLen), (size_t)(extraLen))):NULL, (int)primaryLen, (int)extraLen, ILibMemory_Types_HEAP)
 	#define ILibMemory_SmartAllocate_FromString(str) ILibMemory_SmartAllocate_FromStringEx(str, 0)
 	char* ILibMemory_SmartAllocate_FromStringEx(char *str, size_t strLen);
 	void* ILibMemory_SmartReAllocate(void *ptr, size_t len);


### PR DESCRIPTION
# Summary
This fixes an issue with the MSVC toolsets v143 & 145 for x86.

MSVC x86 (x64 has no issue) link-time code generation (v143 and v145, v142 verified unaffected) drops the conditional part (extraLen > 0 ? header + roundup : 0) of the ILibMemory_Init_Size macro when the sizes are not constants. So the first block with a non-zero extraLen got 44 bytes instead of 88, and every x86 Release build died at startup with 0xC0000374 (STATUS_HEAP_CORRUPTION). The same LTCG build also dropped two of the four ILibMemory_Size_Validate checks. Both are now static inline functions for runtime sizes. The macros stay for the constant-size callers.

Other solution would be disabling LTCG, but this costs nothing performance-wise and makes it independent of the LTCG option and prevents future issues.

Also reported this to microsoft visual studio developer community as it is a toolset issue:
https://developercommunity.visualstudio.com/t/MSVC-x86-LTCG-drops-conditional-malloc-s/11144471?webReport=true

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [x] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [ ] 📦 If I changed JavaScript modules under `modules/`, I re-embedded them so the compiled-in copies in
      `microscript/ILibDuktape_Polyfills.c` match (the agent runs the embedded copies, not the files on disk).
- [x] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [ ] 📄 Documentation updates are included (if applicable), e.g. the `.msh` options table in [readme.md](../readme.md).
- [ ] 🧰 Updates to vendored dependencies (OpenSSL, zlib, ...) are listed and explained.
- [ ] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>

## Testing

Tested through (stress)testscripts and with a serverconnectivity test (desktop/files/terminal/console) on win/linux x86/x64
