### PR TITLE
Name the control channel commands in the controlChannelDebug trace

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -647,7 +647,7 @@ void UDPSocket_OnData(ILibAsyncUDPSocket_SocketModule socketModule, char* buffer
 		if (agentHost->controlChannelDebug != 0)
 		{
 			printf("Received encrypted discovery response...\n");
-			ILIBLOGMESSAGEX("Received encrypted discovery response...\n");
+			ILIBLOGMESSAGEX("Received encrypted discovery response...");
 		}
 	}
 	else
@@ -660,7 +660,7 @@ void UDPSocket_OnData(ILibAsyncUDPSocket_SocketModule socketModule, char* buffer
 		if (agentHost->controlChannelDebug != 0)
 		{
 			printf("Received unencrypted discovery response...\n");
-			ILIBLOGMESSAGEX("Received unencrypted discovery response...\n");
+			ILIBLOGMESSAGEX("Received unencrypted discovery response...");
 		}
 	}
 
@@ -677,7 +677,7 @@ void UDPSocket_OnData(ILibAsyncUDPSocket_SocketModule socketModule, char* buffer
 		if (agentHost->controlChannelDebug != 0)
 		{
 			printf("FoundServer: %s\n", agentHost->multicastServerUrl);
-			ILIBLOGMESSAGEX("FoundServer: %s\n", agentHost->multicastServerUrl);
+			ILIBLOGMESSAGEX("FoundServer: %s", agentHost->multicastServerUrl);
 		}
 
 		if (agentHost->serverConnectionState == 0) { MeshServer_ConnectEx(agentHost); }
@@ -687,7 +687,7 @@ void UDPSocket_OnData(ILibAsyncUDPSocket_SocketModule socketModule, char* buffer
 		if (agentHost->controlChannelDebug != 0)
 		{
 			printf("Failed to parse response...\n");
-			ILIBLOGMESSAGEX("Failed to parse response...\n");
+			ILIBLOGMESSAGEX("Failed to parse response...");
 		}
 	}
 }
@@ -2760,7 +2760,7 @@ void MeshServer_selfupdate_continue(MeshAgentHostContainer *agent)
 		// Windows Console Mode updater
 		if (duk_peval_string(agent->meshCoreCtx, "require('agent-installer').consoleUpdate();") != 0)
 		{
-			printf("%s", duk_safe_to_string(agent->meshCoreCtx, -1));
+			printf("%s\n", duk_safe_to_string(agent->meshCoreCtx, -1));
 		}
 	}
 	else
@@ -2858,7 +2858,19 @@ duk_ret_t MeshServer_selfupdate_unzip_error(duk_context *ctx)
 	return(0);
 }
 
-// Process MeshCentral server commands. 
+// The MeshCommands_Binary identifier for a control channel command number, minus its MeshCommand_ prefix, generated from the MESH_COMMANDS list in agentcore.h
+static const char* MeshCommand_Name(unsigned short command)
+{
+	switch (command)
+	{
+#define MESH_COMMAND_NAME(id, value) case id: return(&#id[sizeof("MeshCommand_") - 1]);
+		MESH_COMMANDS(MESH_COMMAND_NAME)
+#undef MESH_COMMAND_NAME
+		default: return((command & 0xFF00) == 0x7B00 ? "JSON" : "unknown");
+	}
+}
+
+// Process MeshCentral server commands.
 void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAgentHostContainer *agent, char *cmd, int cmdLen)
 {
 	unsigned short command = ntohs(((unsigned short*)cmd)[0]);
@@ -2866,8 +2878,8 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 
 	if (agent->controlChannelDebug != 0)
 	{
-		printf("ProcessCommand(%u)...\n", command);
-		ILIBLOGMESSAGEX("ProcessCommand(%u)...", command);
+		printf("ProcessCommand (%u) %s\n", command, MeshCommand_Name(command));
+		ILIBLOGMESSAGEX("ProcessCommand (%u) %s", command, MeshCommand_Name(command));
 	}
 
 #ifndef MICROSTACK_NOTLS
@@ -2881,7 +2893,7 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 		case MeshCommand_AuthRequest: // This is basic authentication information from the server, we need to sign this and return the signature.
 			if (cmdLen == sizeof(MeshCommand_BinaryPacket_AuthRequest))
 			{
-				if (agent->controlChannelDebug != 0) { ILIBLOGMESSAGEX("Processing Authentication Request..."); }
+				if (agent->controlChannelDebug != 0) { printf("Processing Authentication Request...\n"); ILIBLOGMESSAGEX("Processing Authentication Request..."); }
 				MeshCommand_BinaryPacket_AuthRequest *AuthRequest = (MeshCommand_BinaryPacket_AuthRequest*)cmd;
 				int signLen;
 				SHA512_CTX c;
@@ -2956,7 +2968,7 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 		case MeshCommand_AuthVerify: // This is the signature from the server. We need to check everything is ok.
 			if (cmdLen > 8)
 			{
-				if (agent->controlChannelDebug != 0) { ILIBLOGMESSAGEX("Processing Authentication Verification..."); }
+				if (agent->controlChannelDebug != 0) { printf("Processing Authentication Verification...\n"); ILIBLOGMESSAGEX("Processing Authentication Verification..."); }
 
 				MeshCommand_BinaryPacket_AuthVerify_Header *avh = (MeshCommand_BinaryPacket_AuthVerify_Header*)cmd;
 #ifdef WIN32
@@ -2986,8 +2998,9 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 						X509_pubkey_digest(serverCert, EVP_sha256(), (unsigned char*)ILibScratchPad, (unsigned int*)&hashlen); // OpenSSL 1.1, SHA256 (For older .mshx policy file)
 						if (memcmp(ILibScratchPad, agent->serverHash, UTIL_SHA256_HASHSIZE) != 0) 
 						{
-							printf("Server certificate mismatch\r\n"); break; // TODO: Disconnect
+							printf("Server certificate mismatch\r\n");	// TODO: Disconnect
 							if (agent->controlChannelDebug != 0) { ILIBLOGMESSAGEX("Server certificate mismatch"); }
+							break;
 						}
 					}
 
@@ -3128,8 +3141,8 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 
 	if (agent->controlChannelDebug != 0) 
 	{
-		printf("BinaryCommand(%u, %u)...\n", command, requestid);
-		ILIBLOGMESSAGEX("BinaryCommand(%u, %u)...", command, requestid); 
+		printf("BinaryCommand (%u) %s, request %u\n", command, MeshCommand_Name(command), requestid);
+		ILIBLOGMESSAGEX("BinaryCommand (%u) %s, request %u", command, MeshCommand_Name(command), requestid);
 	}
 
 
@@ -3264,8 +3277,8 @@ void MeshServer_ProcessCommand(ILibWebClient_StateObject WebStateObject, MeshAge
 		}
 		case MeshCommand_CoreOk: // Message from the server indicating our meshcore is ok. No update needed.
 		{
-			printf("Server verified meshcore...");
-			
+			printf("Server verified meshcore...\n");
+			if (agent->controlChannelDebug != 0) { ILIBLOGMESSAGEX("Server verified meshcore..."); }
 			duk_eval_string(agent->meshCoreCtx, "_MSH().setuid;");
 			if (duk_is_null_or_undefined(agent->meshCoreCtx, -1) == 0)
 			{
@@ -3505,7 +3518,7 @@ void MeshServer_ControlChannel_IdleTimeout_PongTimeout(void *object)
 	if (agent->controlChannelDebug != 0)
 	{
 		printf("AgentCore/MeshServer_ControlChannel_IdleTimeout(): PONG TIMEOUT\n");
-		ILIBLOGMESSAGEX("AgentCore/MeshServer_ControlChannel_IdleTimeout(): PONG TIMEOUT\n");
+		ILIBLOGMESSAGEX("AgentCore/MeshServer_ControlChannel_IdleTimeout(): PONG TIMEOUT");
 	}
 	ILibWebClient_Disconnect(agent->controlChannel);
 	agent->controlChannel = NULL;
@@ -3517,7 +3530,7 @@ void MeshServer_ControlChannel_IdleTimeout(ILibWebClient_StateObject WebStateObj
 	if (agent->controlChannelDebug != 0)
 	{
 		printf("AgentCore/MeshServer_ControlChannel_IdleTimeout(): Sending Ping\n");
-		ILIBLOGMESSAGEX("AgentCore/MeshServer_ControlChannel_IdleTimeout(): Sending Ping\n");
+		ILIBLOGMESSAGEX("AgentCore/MeshServer_ControlChannel_IdleTimeout(): Sending Ping");
 	}
 
 	ILibLifeTime_Add(ILibGetBaseTimer(agent->chain), Agent2PingData(agent), 5, MeshServer_ControlChannel_IdleTimeout_PongTimeout, NULL);
@@ -3536,7 +3549,7 @@ void MeshServer_ControlChannel_PongSink(ILibWebClient_StateObject WebStateObject
 	if (agent->controlChannelDebug != 0)
 	{
 		printf("AgentCore/MeshServer_ControlChannel_IdleTimeout(): Pong Received\n");
-		ILIBLOGMESSAGEX("AgentCore/MeshServer_ControlChannel_IdleTimeout(): Pong Received\n");
+		ILIBLOGMESSAGEX("AgentCore/MeshServer_ControlChannel_IdleTimeout(): Pong Received");
 	}
 
 #ifdef _REMOTELOGGING
@@ -4146,8 +4159,10 @@ void MeshServer_ConnectEx(MeshAgentHostContainer *agent)
 	if (useproxy != 0 || meshServer.sin6_family != AF_UNSPEC)
 	{
 		if (useproxy == 0) { strcpy_s(agent->serverip, sizeof(agent->serverip), ILibRemoteLogging_ConvertAddress((struct sockaddr*)&meshServer)); }
-		printf("Connecting %sto: %s\n", useproxy!=0?"(via proxy) ":"", agent->serveruri);
-		if (agent->logUpdate != 0 || agent->controlChannelDebug != 0) { ILIBLOGMESSAGEX("Connecting %sto: %s", useproxy != 0 ? "(via proxy) " : "", agent->serveruri); }
+		printf("Connecting %sto: %s\n", useproxy != 0 ? "(via proxy) " : "", agent->serveruri);
+		if (agent->logUpdate != 0 || agent->controlChannelDebug != 0) {
+			ILIBLOGMESSAGEX("Connecting %sto: %s", useproxy != 0 ? "(via proxy) " : "", agent->serveruri);
+		}
 
 		ILibWebClient_AddWebSocketRequestHeaders(req, 65535, MeshServer_OnSendOK);
 
@@ -4259,7 +4274,7 @@ void MeshServer_Agent_SelfTest(MeshAgentHostContainer *agent)
 
 	if (duk_peval_string(agent->meshCoreCtx, "require('agent-selftest')();") != 0)
 	{
-		printf("   -> Loading Test Script.................[FAILED] %s", duk_safe_to_string(agent->meshCoreCtx, -1));
+		printf("   -> Loading Test Script.................[FAILED] %s\n", duk_safe_to_string(agent->meshCoreCtx, -1));
 		exit(1);
 	}
 	duk_pop(agent->meshCoreCtx);
@@ -4332,16 +4347,17 @@ void MeshServer_Connect(MeshAgentHostContainer *agent)
 	SLAVELOG = ILibSimpleDataStore_Get(agent->masterDb, "slaveKvmLog", NULL, 0);
 #endif
 
-	if (agent->logUpdate != 0) { ILIBLOGMESSAGEX("PLATFORM_TYPE: %d", agent->platformType); }
-	if (agent->logUpdate != 0) { ILIBLOGMESSAGEX("Running as Service: %d", agent->JSRunningAsService); }
-
-	if (agent->logUpdate != 0) { ILIBLOGMESSSAGE("Attempting to connect to Server..."); }
-	if (agent->controlChannelDebug != 0)
+	if (agent->logUpdate != 0)
 	{
-		ILIBLOGMESSSAGE("Attempting to connect to Server...");
-		printf("Attempting to connect to Server...\n");
+		ILIBLOGMESSAGEX("PLATFORM_TYPE: %d", agent->platformType);
+		ILIBLOGMESSAGEX("Running as Service: %d", agent->JSRunningAsService);
 	}
-	else if (agent->logUpdate != 0) { ILIBLOGMESSSAGE("Attempting to connect to Server..."); }
+
+	if (agent->logUpdate != 0 || agent->controlChannelDebug != 0)
+	{
+		printf("Attempting to connect to Server...\n");
+		ILIBLOGMESSSAGE("Attempting to connect to Server...");
+	}
 
 	if (agent->retryTime == 0)
 	{
@@ -4646,7 +4662,7 @@ void MeshAgent_AgentMode_IPAddressChanged_Handler(ILibIPAddressMonitor sender, v
 	if (agentHost->controlChannelDebug != 0)
 	{
 		printf("MeshAgent_AgentMode_IPAddressChanged_Handler(%d)\n", agentHost->serverConnectionState);
-		ILIBLOGMESSAGEX("MeshAgent_AgentMode_IPAddressChanged_Handler(%d)\n", agentHost->serverConnectionState);
+		ILIBLOGMESSAGEX("MeshAgent_AgentMode_IPAddressChanged_Handler(%d)", agentHost->serverConnectionState);
 	}
 
 	if (agentHost->multicastDiscovery != NULL)
@@ -4654,7 +4670,7 @@ void MeshAgent_AgentMode_IPAddressChanged_Handler(ILibIPAddressMonitor sender, v
 		if (agentHost->controlChannelDebug != 0)
 		{
 			printf("Resetting MulticastSocketv4\n");
-			ILIBLOGMESSAGEX("Resetting MulticastSocketv4\n");
+			ILIBLOGMESSAGEX("Resetting MulticastSocketv4");
 		}
 		ILibMulticastSocket_ResetMulticast(agentHost->multicastDiscovery, 0);
 	}
@@ -4663,7 +4679,7 @@ void MeshAgent_AgentMode_IPAddressChanged_Handler(ILibIPAddressMonitor sender, v
 		if (agentHost->controlChannelDebug != 0)
 		{
 			printf("Resetting MulticastSocketv6\n");
-			ILIBLOGMESSAGEX("Resetting MulticastSocketv6\n");
+			ILIBLOGMESSAGEX("Resetting MulticastSocketv6");
 		}
 		ILibMulticastSocket_ResetMulticast(agentHost->multicastDiscovery2, 0);
 	}

--- a/meshcore/agentcore.h
+++ b/meshcore/agentcore.h
@@ -104,24 +104,30 @@ typedef enum AgentIdentifiers
 // Commands 0 to 9 are reserved for client/server authentication, once authenticated they can't be used and must not be processed.
 // Commands 10 and above must only be processed if the server is authenticated. All these commands have 2 bytes commandid + 2 bytes requestid.
 // Commands with an id that starts with '{' (123, 0x7B) are reserved for JSON commands, that is commands 31488 (0x7B00) to 31743 (0x7BFF)
+// The MeshCommands_Binary enum below and the name switch in MeshCommand_Name() in agentcore.c are generated from this list, so adding a command here updates both.
+
+#define MESH_COMMANDS(X)                                                                                                                                       \
+	X(MeshCommand_AuthRequest,           1)  /* Server web certificate public key sha384 hash + agent or server nonce */                                        \
+	X(MeshCommand_AuthVerify,            2)  /* Agent or server signature */                                                                                   \
+	X(MeshCommand_AuthInfo,              3)  /* Agent information */                                                                                           \
+	X(MeshCommand_AuthConfirm,           4)  /* Server confirm to the agent that is it authenticated */                                                        \
+	X(MeshCommand_ServerId,              5)  /* Optional, agent sends the expected serverid to the server. Useful if the server has many server certificates. */ \
+	X(MeshCommand_CoreModule,           10)  /* New core modules to be used instead of the old one, if empty, remove the core module */                        \
+	X(MeshCommand_CompressedCoreModule, 20)                                                                                                                    \
+	X(MeshCommand_CoreModuleHash,       11)  /* Request/return the SHA384 hash of the core module */                                                           \
+	X(MeshCommand_AgentCommitDate,      30)  /* Commit Date that the agent was built with */                                                                   \
+	X(MeshCommand_AgentHash,            12)  /* Request/return the SHA384 hash of the agent executable */                                                      \
+	X(MeshCommand_AgentUpdate,          13)  /* Indicate the start and end of the mesh agent binary transfer */                                                \
+	X(MeshCommand_AgentUpdateBlock,     14)  /* Part of the mesh agent sent from the server to the agent, confirmation/flowcontrol from agent to server */      \
+	X(MeshCommand_AgentTag,             15)  /* Send the mesh agent tag to the server */                                                                       \
+	X(MeshCommand_CoreOk,               16)  /* Sent by the server to indicate the meshcore is ok */                                                           \
+	X(MeshCommand_HostInfo,             31)  /* Host OS and CPU Architecture */
+
 typedef enum MeshCommands_Binary
 {
-	MeshCommand_AuthRequest				= 1,    // Server web certificate public key sha384 hash + agent or server nonce
-	MeshCommand_AuthVerify				= 2,    // Agent or server signature
-	MeshCommand_AuthInfo				= 3,	// Agent information
-	MeshCommand_AuthConfirm             = 4,	// Server confirm to the agent that is it authenticated
-	MeshCommand_ServerId				= 5,	// Optional, agent sends the expected serverid to the server. Useful if the server has many server certificates.
-	MeshCommand_CoreModule				= 10,	// New core modules to be used instead of the old one, if empty, remove the core module
-	MeshCommand_CompressedCoreModule	= 20,
-	MeshCommand_CoreModuleHash			= 11,	// Request/return the SHA384 hash of the core module
-	MeshCommand_AgentCommitDate			= 30,	// Commit Date that the agent was built with
-	MeshCommand_AgentHash				= 12,	// Request/return the SHA384 hash of the agent executable
-	MeshCommand_AgentUpdate				= 13,   // Indicate the start and end of the mesh agent binary transfer
-	MeshCommand_AgentUpdateBlock		= 14,   // Part of the mesh agent sent from the server to the agent, confirmation/flowcontrol from agent to server
-	MeshCommand_AgentTag				= 15,	// Send the mesh agent tag to the server
-	MeshCommand_CoreOk					= 16,	// Sent by the server to indicate the meshcore is ok
-	MeshCommand_HostInfo				= 31,	// Host OS and CPU Architecture
-
+#define MESH_COMMAND_ENUM(id, value) id = value,
+	MESH_COMMANDS(MESH_COMMAND_ENUM)
+#undef MESH_COMMAND_ENUM
 } MeshCommands_Binary;
 
 #pragma pack(push,1)


### PR DESCRIPTION
ProcessCommand and BinaryCommand now print the MeshCommands_Binary name next to the number so it is more clear what is happening.

To keep only one list of truth the enum is now generated from the #define list, which is also used to generate the switch in the MeshCommand_Name function. Future changes to the command list stay in sync this way.

Also cleaned up the debug output:
- trailing newlines removed from .log entries, missing ones added to printf.
- All controlChannelDebug tracemessages now go to both console and log.
- No duplicate output lines
- Fixed one unreachable log line.

N.B.:
On the todo: the consoleoutput is done through a printf in agentcore.h, but ideally should be done by ILIBLOGMESSAGEX, which can check if consoleoutput is configured. And that's another thing, controlChannelDebug is kind of the switch for it, but really is a loglevel sort of option. Maybe put in a real 'consoleLog' option. But that's bigger and for another PR.

Run through AI and tested on win/linux 32/64

Example consoleoutput:
Connected.
ProcessCommand (1) AuthRequest
ProcessCommand (4) AuthConfirm
Authentication Complete...
ProcessCommand (11) CoreModuleHash
BinaryCommand (11) CoreModuleHash, request 0
ProcessCommand (16) CoreOk
BinaryCommand (16) CoreOk, request 0
Server verified meshcore...ModuleLoader: MeshAgent

Example logoutput (editted for readability):
[ 06:16:32 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) PLATFORM_TYPE: 10
[ 06:16:32 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) Running as Service: 0
[ 06:16:32 PM] [PTR] .\meshcore\agentcore.c:4359 (0,0) Attempting to connect to Server...
[ 06:16:32 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) Connecting to: wss://ptrhost:8443/agent.ashx
[ 06:16:32 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) Control Channel Connection Established [908]...
[ 06:16:32 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) TLS Server Cert matches Mesh Server Cert [908]...
[ 06:16:32 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) Sending Authentication Data...
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) ProcessCommand (1) AuthRequest
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) Processing Authentication Request...
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) ProcessCommand (4) AuthConfirm
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) Authentication Complete...
[ 06:16:41 PM] [PTR] .\meshcore\agentcore.c:2641 (0,0) Connection Established [000001F3CE43C018]...
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) ProcessCommand (11) CoreModuleHash
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) BinaryCommand (11) CoreModuleHash, request 0
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) ProcessCommand (16) CoreOk
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) BinaryCommand (16) CoreOk, request 0
[ 06:16:41 PM] [PTR] .\microstack\ILibParsers.c:11110 (0,0) ProcessCommand (31522) JSON