### PR TITLE
Fix ppc64le link failure: WebSocket ratio functions using long double

### DIFF
--- a/microscript/ILibDuktape_HttpStream.c
+++ b/microscript/ILibDuktape_HttpStream.c
@@ -4976,9 +4976,9 @@ duk_ret_t ILibDuktape_WebSocket_bytesSent_ratio(duk_context *ctx)
 	duk_get_prop_string(ctx, -1, ILibDuktape_WSDEC2WS);						// [WebSocket_Decoded][WebSocket]
 	ws = (ILibDuktape_WebSocket_State*)Duktape_GetBufferProperty(ctx, -1, ILibDuktape_WebSocket_StatePtr);
 
-	long double ratio = (long double)ws->actualSent / (long double)ws->uncompressedSent;
+	double ratio = (double)ws->actualSent / (double)ws->uncompressedSent;
 	ratio = (1 - ratio) * 100;
-	duk_push_number(ctx, floor((double)ratio));
+	duk_push_number(ctx, floor(ratio));
 	
 	return(1);
 }
@@ -4989,9 +4989,9 @@ duk_ret_t ILibDuktape_WebSocket_bytesReceived_ratio(duk_context *ctx)
 	duk_get_prop_string(ctx, -1, ILibDuktape_WSDEC2WS);						// [WebSocket_Decoded][WebSocket]
 	ws = (ILibDuktape_WebSocket_State*)Duktape_GetBufferProperty(ctx, -1, ILibDuktape_WebSocket_StatePtr);
 
-	long double ratio = (long double)ws->actualReceived / (long double)ws->uncompressedReceived;
+	double ratio = (double)ws->actualReceived / (double)ws->uncompressedReceived;
 	ratio = (1 - ratio) * 100;
-	duk_push_number(ctx, floor((double)ratio));
+	duk_push_number(ctx, floor(ratio));
 
 	return(1);
 }


### PR DESCRIPTION
Under clang/compiler-rt toolchain this failed to link on ppc64le with undefined symbol __gcc_qsub / __gcc_qmul.

ILibDuktape_WebSocket_bytesSent_ratio/bytesReceived_ratio calculated the ratio with long doubles. Long double is not a strict defined type per platform, making it less portable. The proper 'long double' precision would be __float128...but (1) it's just a ratio calculation which doesn't need this high precision at all and (2) in the end it returns the floored value as a JS number.

This is the only place in the source where long doubles were used.

Tested with the test scripts on powerpc64 through qemu and linux x86/x64