### PR TITLE
Fix stream mode on windows

### DIFF
--- a/microscript/ILibDuktape_fs.c
+++ b/microscript/ILibDuktape_fs.c
@@ -307,6 +307,9 @@ int ILibDuktape_fs_openSyncEx(duk_context *ctx, char *path, char *flags, char *m
 	int retVal;
 	FILE *f;
 	char *key = ILibScratchPad;
+#ifdef WIN32
+	char binFlags[8];
+#endif
 
 	duk_push_this(ctx);													// [fs]
 	duk_get_prop_string(ctx, -1, FS_NextFD);							// [fs][fd]
@@ -315,6 +318,12 @@ int ILibDuktape_fs_openSyncEx(duk_context *ctx, char *path, char *flags, char *m
 
 	sprintf_s(ILibScratchPad, sizeof(ILibScratchPad), "%d", retVal);
 #ifdef WIN32
+	// node has no text mode, so force binary on Windows, as it's default mode is text.
+	if (strchr(flags, 'b') == NULL && strchr(flags, 't') == NULL)
+	{
+		sprintf_s(binFlags, sizeof(binFlags), "%.6sb", flags);
+		flags = binFlags;
+	}
 	_wfopen_s(&f, (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, path), (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, flags));
 #else
 	f = fopen(path, flags);
@@ -1111,7 +1120,7 @@ duk_ret_t ILibDuktape_fs_createWriteStream(duk_context *ctx)
 #else
 	char *path = ILibDuktape_fs_fixLinuxPath((char*)duk_require_string(ctx, 0));
 #endif
-	char *flags = "w";
+	char *flags = "wb";
 	int fd = 0;
 	FILE *f;
 	ILibDuktape_fs_writeStreamData *data;
@@ -1284,7 +1293,7 @@ duk_ret_t ILibDuktape_fs_createReadStream(duk_context *ctx)
 #else
 	char *path = ILibDuktape_fs_fixLinuxPath((char*)duk_require_string(ctx, 0));
 #endif
-	char *flags = "r";
+	char *flags = "rb";
 	int fd = 0;
 	FILE *f;
 	ILibDuktape_fs_readStreamData *data;
@@ -1296,7 +1305,7 @@ duk_ret_t ILibDuktape_fs_createReadStream(duk_context *ctx)
 	if (nargs > 1)
 	{
 		fd = Duktape_GetIntPropertyValue(ctx, 1, "fd", 0);
-		flags = Duktape_GetStringPropertyValue(ctx, 1, "flags", "r");
+		flags = Duktape_GetStringPropertyValue(ctx, 1, "flags", "rb");
 		if (duk_has_prop_string(ctx, 1, "autoClose"))
 		{
 			duk_get_prop_string(ctx, 1, "autoClose");
@@ -2448,6 +2457,9 @@ duk_ret_t ILibDuktape_fs_readFileSync(duk_context *ctx)
 	char *filePath = (char*)duk_require_string(ctx, 0);
 	FILE *f;
 	long fileLen;
+#ifdef WIN32
+	char binFlags[8];
+#endif
 
 #ifdef WIN32
 	char *flags = "rbN";
@@ -2461,6 +2473,12 @@ duk_ret_t ILibDuktape_fs_readFileSync(duk_context *ctx)
 	}
 
 #ifdef WIN32
+	// An options object can replace the "rbN" default above, force binary
+	if (strchr(flags, 'b') == NULL && strchr(flags, 't') == NULL)
+	{
+		sprintf_s(binFlags, sizeof(binFlags), "%.6sb", flags);
+		flags = binFlags;
+	}
 	_wfopen_s(&f, (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, filePath), (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, flags));
 #else
 	f = fopen(filePath, flags);


### PR DESCRIPTION
# Summary
fs defaulted to "r" and "w", which on windows is a text stream.
Node has no text mode, and on posix text and binary streams are identical, so a mode string without b or t should open binary.

A text stream expands every written \n to \r\n, and a read stops at the first 0x1A byte, which it reads as an end of file.
ILibDuktape_fs_openSyncEx/readFileSync now appends b when the called without b or t.

createReadStream/createWriteStream also default to "rb"/"wb", even though openSyncEx already forces it.

<details>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [x] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [ ] 📦 If I changed JavaScript modules under `modules/`, I re-embedded them so the compiled-in copies in
      `microscript/ILibDuktape_Polyfills.c` match (the agent runs the embedded copies, not the files on disk).
- [x] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [ ] 📄 Documentation updates are included (if applicable), e.g. the `.msh` options table in [readme.md](../readme.md).
- [ ] 🧰 Updates to vendored dependencies (OpenSSL, zlib, ...) are listed and explained.
- [x] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>

## Testing
Tested on win x86/x64 and linux agents