### PR TITLE
macOS: Put kvm debug messages behind compile option

### DIFF
--- a/makefile
+++ b/makefile
@@ -161,6 +161,7 @@
 #	IFADDR_DISABLE							1 = Don't use ifaddrs.h				=> Default is use IFADDR
 #	KVM										1 = KVM Enabled, 0 = KVM Disabled   => Default depends on ARCHID
 #	KVM_ALL_TILES							0 = Normal, 1 = All Tiles			=> Default is Normal Tiling Algorithm
+#	KVMDEBUG								1 = KVM helper trace log			=> Default is disabled (Windows and macOS KVM only)
 #	LEGACY_LD								0 = Standard, 1 = Legacy			=> Default is Standard (CentOS 5.11 requires Legacy)
 #	NET_SEND_FORCE_FRAGMENT					1 = net.send() fragments sends		=> Default is normal send operation
 #	NOTLS									1 = TLS Support Compiled Out		=> Default is TLS Support Compiled In
@@ -697,6 +698,9 @@ endif
 
 ifeq ($(KVM_ALL_TILES),1)
 CFLAGS += -DKVM_ALL_TILES
+endif
+ifeq ($(KVMDEBUG),1)
+CFLAGS += -DKVMDEBUGENABLED
 endif
 
 ifeq ($(BIGCHAINLOCK),1)

--- a/meshcore/KVM/MacOS/mac_kvm.c
+++ b/meshcore/KVM/MacOS/mac_kvm.c
@@ -76,6 +76,7 @@ void kvm_set_listener_path(const char *path)
 
 
 int KVM_AGENT_FD = -1;
+int KVM_STDOUT_IS_LOG = 0;
 int KVM_SEND(char *buffer, int bufferLen)
 {
 	int retVal = -1;
@@ -124,17 +125,26 @@ pthread_t kvmthread = (pthread_t)NULL;
 ILibProcessPipe_Process gChildProcess;
 ILibQueue g_messageQ;
 
-//int logenabled = 1;
-//FILE *logfile = NULL;
-//#define MASTERLOGFILE "/dev/null"
-//#define SLAVELOGFILE "/dev/null"
-//#define LOGFILE "/dev/null"
+// #define KVMDEBUGENABLED 1
+#ifdef KVMDEBUGENABLED
+static void KvmDebugLog(const char *format, ...)
+{
+	char tmp[255];
+	int len;
+	va_list args;
 
-
+	if (KVM_STDOUT_IS_LOG == 0) { return; }
+	va_start(args, format);
+	len = vsnprintf(tmp, sizeof(tmp), format, args);
+	va_end(args);
+	if (len <= 0) { return; }
+	if (len > (int)sizeof(tmp) - 1) { len = (int)sizeof(tmp) - 1; }
+	write(STDOUT_FILENO, tmp, len);
+	fsync(STDOUT_FILENO);
+}
+#else
 #define KvmDebugLog(...)
-//#define KvmDebugLog(...) printf(__VA_ARGS__); if (logfile != NULL) fprintf(logfile, __VA_ARGS__);
-//#define KvmDebugLog(x) if (logenabled) printf(x);
-//#define KvmDebugLog(x) if (logenabled) fprintf(logfile, "Writing from slave in kvm_send_resolution\n");
+#endif
 
 void senddebug(int val)
 {
@@ -503,9 +513,6 @@ void* kvm_mainloopinput(void* param)
 	char* pchRequest2[30000];
 	int cbBytesRead = 0;
 
-	char tmp[255];
-	int tmpLen;
-
 	if (KVM_AGENT_FD == -1)
 	{
 		int flags;
@@ -515,23 +522,9 @@ void* kvm_mainloopinput(void* param)
 
 	while (!g_shutdown)
 	{
-		if (KVM_AGENT_FD != -1)
-		{
-			tmpLen = sprintf_s(tmp, sizeof(tmp), "About to read from IPC Socket\n");
-			write(STDOUT_FILENO, tmp, tmpLen);
-			fsync(STDOUT_FILENO);
-		}
-
-		KvmDebugLog("Reading from master in kvm_mainloopinput\n");
+		KvmDebugLog("About to read from IPC Socket\n");
 		cbBytesRead = read(KVM_AGENT_FD == -1 ? STDIN_FILENO: KVM_AGENT_FD, pchRequest2 + len, 30000 - len);
-		KvmDebugLog("Read %d bytes from master in kvm_mainloopinput\n", cbBytesRead);
-
-		if (KVM_AGENT_FD != -1)
-		{
-			tmpLen = sprintf_s(tmp, sizeof(tmp), "Read %d bytes from IPC-xx-Socket\n", cbBytesRead);
-			write(STDOUT_FILENO, tmp, tmpLen);
-			fsync(STDOUT_FILENO);
-		}
+		KvmDebugLog("Read %d bytes from IPC Socket\n", cbBytesRead);
 
 		if (cbBytesRead == -1 || cbBytesRead == 0) 
 		{ 
@@ -549,20 +542,9 @@ void* kvm_mainloopinput(void* param)
 		len += cbBytesRead;
 		ptr2 = 0;
 		
-		if (KVM_AGENT_FD != -1)
-		{
-			tmpLen = sprintf_s(tmp, sizeof(tmp), "enter while\n");
-			write(STDOUT_FILENO, tmp, tmpLen);
-			fsync(STDOUT_FILENO);
-		}
+		KvmDebugLog("enter while\n");
 		while ((ptr2 = kvm_server_inputdata((char*)pchRequest2 + ptr, cbBytesRead - ptr)) != 0) { ptr += ptr2; }
-
-		if (KVM_AGENT_FD != -1)
-		{
-			tmpLen = sprintf_s(tmp, sizeof(tmp), "exited while\n");
-			write(STDOUT_FILENO, tmp, tmpLen);
-			fsync(STDOUT_FILENO);
-		}
+		KvmDebugLog("exited while\n");
 
 		if (ptr == len) { len = 0; ptr = 0; }
 		// TODO: else move the reminder.
@@ -606,6 +588,7 @@ void* kvm_server_mainloop(void* param)
 	else
 	{
 		// this is doing I/O via a Unix Domain Socket
+		KVM_STDOUT_IS_LOG = 1;
 		if ((KVM_Listener_FD = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
 		{
 			char tmp[255];
@@ -620,8 +603,7 @@ void* kvm_server_mainloop(void* param)
 		flags = fcntl(KVM_Listener_FD, F_GETFL, 0);
 		if (fcntl(KVM_Listener_FD, F_SETFL, (O_NONBLOCK | flags) ^ O_NONBLOCK) == -1) { }
 
-		written = write(STDOUT_FILENO, "Set FCNTL2\n", 11);
-		fsync(STDOUT_FILENO);
+		KvmDebugLog("Set FCNTL2\n");
 
 		memset(&serveraddr, 0, sizeof(serveraddr));
 		serveraddr.sun_family = AF_UNIX;
@@ -673,16 +655,7 @@ void* kvm_server_mainloop(void* param)
 	pthread_create(&kvmthread, NULL, kvm_mainloopinput, param);
 
 
-	if (KVM_AGENT_FD != -1)
-	{
-		written = write(STDOUT_FILENO, "Starting Loop []\n", 14);
-		fsync(STDOUT_FILENO);
-
-		char stmp[255];
-		int stmpLen = sprintf_s(stmp, sizeof(stmp), "TILE_HEIGHT_COUNT=%d, TILE_WIDTH_COUNT=%d\n", TILE_HEIGHT_COUNT, TILE_WIDTH_COUNT);
-		written = write(STDOUT_FILENO, stmp, stmpLen);
-		fsync(STDOUT_FILENO);
-	}
+	KvmDebugLog("Starting Loop [] TILE_HEIGHT_COUNT=%d, TILE_WIDTH_COUNT=%d\n", TILE_HEIGHT_COUNT, TILE_WIDTH_COUNT);
 
 	while (!g_shutdown) 
 	{
@@ -775,13 +748,7 @@ void* kvm_server_mainloop(void* param)
 			//senddebug(100);
 			getScreenBuffer((unsigned char **)&desktop, &desktopsize, image);
 
-			if (KVM_AGENT_FD != -1)
-			{
-				char tmp[255];
-				int tmpLen = sprintf_s(tmp, sizeof(tmp), "...Enter for loop\n");
-				written = write(STDOUT_FILENO, tmp, tmpLen);
-				fsync(STDOUT_FILENO);
-			}
+			KvmDebugLog("...Enter for loop\n");
 
 			for (y = 0; y < TILE_HEIGHT_COUNT; y++) 
 			{
@@ -828,13 +795,7 @@ void* kvm_server_mainloop(void* param)
 				}
 			}
 
-			if (KVM_AGENT_FD != -1)
-			{
-				char tmp[255];
-				int tmpLen = sprintf_s(tmp, sizeof(tmp), "...exit for loop\n");
-				written = write(STDOUT_FILENO, tmp, tmpLen);
-				fsync(STDOUT_FILENO);
-			}
+			KvmDebugLog("...exit for loop\n");
 
 		}
 		CGImageRelease(image);
@@ -850,11 +811,7 @@ void* kvm_server_mainloop(void* param)
 		tilebuffer = NULL;
 	}
 
-	if (KVM_AGENT_FD != -1)
-	{
-		written = write(STDOUT_FILENO, "Exiting...\n", 11);
-		fsync(STDOUT_FILENO);
-	}
+	KvmDebugLog("Exiting...\n");
 	ILibQueue_Destroy(g_messageQ);
 	return (void*)0;
 }


### PR DESCRIPTION
# Summary

Also seen through the testing of the mac agent via terminal start.

As soon as a desktop session started, the console was flooded with dev debug messages. Put the already commented 'KvmDebugLog()' function in behind KVMDEBUGENABLED (enable through KVMDEBUG=1 in the make command) and replaced the debug messages with the the KvmDebugLog().
Default is off, so no more flooding.

The ...loop messages were send per frame, that were many

Example:
About to read from IPC Socket
...Enter for loop
Read 10 bytes from IPC-xx-Socket
enter while
exited while
About to read from IPC Socket
...exit for loop
...Enter for loop
...exit for loop
...Enter for loop
...exit for loop
...Enter for loop
...exit for loop
...Enter for loop
...exit for loop
...Enter for loop
...exit for loop
...Enter for loop

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [x] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [ ] 📦 If I changed JavaScript modules under `modules/`, I re-embedded them so the compiled-in copies in
      `microscript/ILibDuktape_Polyfills.c` match (the agent runs the embedded copies, not the files on disk).
- [x] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [ ] 📄 Documentation updates are included (if applicable), e.g. the `.msh` options table in [readme.md](../readme.md).
- [ ] 🧰 Updates to vendored dependencies (OpenSSL, zlib, ...) are listed and explained.
- [x] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>

## Testing

Tested on macos arm64/x64
