### PR TITLE
files: open files the way node's fs does

### DIFF
--- a/meshcore/agentcore.c
+++ b/meshcore/agentcore.c
@@ -428,7 +428,7 @@ size_t MeshAgent_Linux_ReadMemFile(char *path, char **buffer)
 {
 	size_t i = 0, r, sz = 4096;
 	*buffer = NULL;
-	FILE *f = fopen(path, "rb");
+	FILE *f = ILibFile_Open(path, "rb");
 	if (f != NULL)
 	{
 		if ((*buffer = malloc(sz)) == NULL) { ILIBCRITICALEXIT(254); }
@@ -2598,10 +2598,8 @@ int GenerateSHA384FileHash(char *filePath, char *fileHash)
 
 #ifdef WIN32
 	int retVal = 1;
-	_wfopen_s(&tmpFile, ILibUTF8ToWide(filePath, -1), L"rb");
-#else
-	tmpFile = fopen(filePath, "rb");
 #endif
+	tmpFile = ILibFile_Open(filePath, "rb");
 	if (tmpFile == NULL) { return(1); }
 
 #ifdef WIN32
@@ -4512,11 +4510,7 @@ void checkForEmbeddedMSH_ex(MeshAgentHostContainer *agent, char **eMSH)
 
 	if (eMSH != NULL) { *eMSH = NULL; }
 
-#ifdef WIN32
-	_wfopen_s(&tmpFile, ILibUTF8ToWide(agent->exePath, -1), L"rb");
-#else
-	tmpFile = fopen(agent->exePath, "rb");
-#endif
+	tmpFile = ILibFile_Open(agent->exePath, "rb");
 	if (tmpFile == NULL) { return; }
 
 	fseek(tmpFile, -16, SEEK_END);
@@ -4537,11 +4531,7 @@ void checkForEmbeddedMSH_ex(MeshAgentHostContainer *agent, char **eMSH)
 				if (eMSH == NULL)
 				{
 					FILE *msh = NULL;
-#ifdef WIN32
-					_wfopen_s(&msh, ILibUTF8ToWide(MeshAgent_MakeAbsolutePath(agent->exePath, ".msh"), -1), L"wb");
-#else
-					msh = fopen(MeshAgent_MakeAbsolutePath(agent->exePath, ".msh"), "wb");
-#endif
+					msh = ILibFile_Open(MeshAgent_MakeAbsolutePath(agent->exePath, ".msh"), "wb");
 					if (msh != NULL)
 					{
 						ignore_result(fwrite(data, 1, mshLen, msh));
@@ -4908,8 +4898,8 @@ int MeshAgent_AgentMode(MeshAgentHostContainer *agentHost, int paramLen, char **
 			pid_t pid = 0;
 			size_t len;
 
-			fd = fopen("/var/run/meshagent.pid", "r");
-			if (fd == NULL) fd = fopen(".meshagent.pid", "r");
+			fd = ILibFile_Open("/var/run/meshagent.pid", "r");
+			if (fd == NULL) fd = ILibFile_Open(".meshagent.pid", "r");
 			if (fd != NULL)
 			{
 				len = fread(str, sizeof(char), 15, fd);
@@ -5528,8 +5518,8 @@ int MeshAgent_AgentMode(MeshAgentHostContainer *agentHost, int paramLen, char **
 		{
 			len = sprintf_s(str, 15, "%d\r\n", pid);
 
-			fd = fopen("/var/run/meshagent.pid", "w");
-			if (fd == NULL) fd = fopen(".meshagent.pid", "w");
+			fd = ILibFile_Open("/var/run/meshagent.pid", "w");
+			if (fd == NULL) fd = ILibFile_Open(".meshagent.pid", "w");
 			if (fd != NULL)
 			{
 				if (fwrite(str, sizeof(char), len, fd)) {}

--- a/meshcore/meshinfo.c
+++ b/meshcore/meshinfo.c
@@ -188,7 +188,7 @@ int __fastcall utilx_readfile2(char* filename, char** data)
 	*data = NULL;
 	if (filename == NULL) return 0;
 
-	pFile = fopen(filename, "rb");
+	pFile = ILibFile_Open(filename, "rb");
 	if (pFile != NULL)
 	{
 		*data = malloc(1024);

--- a/microscript/ILibDuktape_ScriptContainer.c
+++ b/microscript/ILibDuktape_ScriptContainer.c
@@ -316,7 +316,7 @@ void ILibDuktape_ScriptContainer_CheckEmbeddedEx(char *exePath, char **script, i
 	{
 		i = sprintf_s(g_AgentCrashID, sizeof(g_AgentCrashID), "%s_", exePath);
 		sprintf_s(ILibScratchPad, sizeof(ILibScratchPad), "%s.exe", exePath);
-		_wfopen_s(&tmpFile, ILibUTF8ToWide(ILibScratchPad, -1), L"rb");
+		tmpFile = ILibFile_Open(ILibScratchPad, "rb");
 	}
 	else
 	{
@@ -350,11 +350,7 @@ void ILibDuktape_ScriptContainer_CheckEmbeddedEx(char *exePath, char **script, i
 #endif
 	}
 
-#ifdef WIN32
-	_wfopen_s(&tmpFile, ILibUTF8ToWide(exePath, -1), L"rb");
-#else
-	tmpFile = fopen(exePath, "rb");
-#endif
+	tmpFile = ILibFile_Open(exePath, "rb");
 
 	if (tmpFile != NULL)
 	{

--- a/microscript/ILibDuktape_fs.c
+++ b/microscript/ILibDuktape_fs.c
@@ -307,9 +307,6 @@ int ILibDuktape_fs_openSyncEx(duk_context *ctx, char *path, char *flags, char *m
 	int retVal;
 	FILE *f;
 	char *key = ILibScratchPad;
-#ifdef WIN32
-	char binFlags[8];
-#endif
 
 	duk_push_this(ctx);													// [fs]
 	duk_get_prop_string(ctx, -1, FS_NextFD);							// [fs][fd]
@@ -317,17 +314,7 @@ int ILibDuktape_fs_openSyncEx(duk_context *ctx, char *path, char *flags, char *m
 	duk_pop(ctx);														// [fs]
 
 	sprintf_s(ILibScratchPad, sizeof(ILibScratchPad), "%d", retVal);
-#ifdef WIN32
-	// node has no text mode, so force binary on Windows, as it's default mode is text.
-	if (strchr(flags, 'b') == NULL && strchr(flags, 't') == NULL)
-	{
-		sprintf_s(binFlags, sizeof(binFlags), "%.6sb", flags);
-		flags = binFlags;
-	}
-	_wfopen_s(&f, (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, path), (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, flags));
-#else
-	f = fopen(path, flags);
-#endif
+	f = ILibFile_Open(path, flags);
 	if (f != NULL)
 	{
 		// MAP FILE* to FD
@@ -394,7 +381,8 @@ duk_ret_t ILibDuktape_fs_openSync(duk_context *ctx)
 	{
 		dwCreationMode = OPEN_EXISTING;
 	}
-	fd = CreateFileW((wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, path), dwDesiredAccess, 0, NULL, dwCreationMode, FILE_FLAG_OVERLAPPED, NULL);
+	// Share mode 0 blocked every later open, this process included.
+	fd = CreateFileW((wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, path), dwDesiredAccess, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, dwCreationMode, FILE_FLAG_OVERLAPPED, NULL);
 	if (fd == INVALID_HANDLE_VALUE)
 	{
 		DWORD err = GetLastError();
@@ -2457,32 +2445,14 @@ duk_ret_t ILibDuktape_fs_readFileSync(duk_context *ctx)
 	char *filePath = (char*)duk_require_string(ctx, 0);
 	FILE *f;
 	long fileLen;
-#ifdef WIN32
-	char binFlags[8];
-#endif
-
-#ifdef WIN32
-	char *flags = "rbN";
-#else
 	char *flags = "rb";
-#endif
 
 	if (duk_is_object(ctx, 1))
 	{
 		flags = Duktape_GetStringPropertyValue(ctx, 1, "flags", flags);
 	}
 
-#ifdef WIN32
-	// An options object can replace the "rbN" default above, force binary
-	if (strchr(flags, 'b') == NULL && strchr(flags, 't') == NULL)
-	{
-		sprintf_s(binFlags, sizeof(binFlags), "%.6sb", flags);
-		flags = binFlags;
-	}
-	_wfopen_s(&f, (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, filePath), (const wchar_t*)ILibDuktape_String_UTF8ToWide(ctx, flags));
-#else
-	f = fopen(filePath, flags);
-#endif
+	f = ILibFile_Open(filePath, flags);
 
 	if (f == NULL) { return(ILibDuktape_Error(ctx, "fs.readFileSync(): File [%s] not found", filePath)); }
 

--- a/microstack/ILibCrypto.c
+++ b/microstack/ILibCrypto.c
@@ -144,11 +144,7 @@ int   __fastcall util_sha384file(char* filename, char* result)
 	char *buf = NULL;
 
 	if (filename == NULL) return -1;
-#ifdef WIN32 
-	_wfopen_s(&pFile, ILibUTF8ToWide(filename, -1), L"rbN");
-#else
-	pFile = fopen(filename, "rb");
-#endif
+	pFile = ILibFile_Open(filename, "rb");
 	if (pFile == NULL) goto error;
 	SHA384_Init(&c);
 	if ((buf = (char*)malloc(4096)) == NULL) goto error;
@@ -284,11 +280,7 @@ size_t __fastcall util_writefile(char* filename, char* data, int datalen)
 	FILE * pFile = NULL;
 	size_t count = 0;
 
-#ifdef WIN32 
-	_wfopen_s(&pFile, ILibUTF8ToWide(filename, -1), L"wbN");
-#else
-	pFile = fopen(filename, "wb");
-#endif
+	pFile = ILibFile_Open(filename, "wb");
 
 	if (pFile != NULL)
 	{
@@ -303,11 +295,7 @@ size_t __fastcall util_appendfile(char* filename, char* data, int datalen)
 	FILE * pFile = NULL;
 	size_t count = 0;
 
-#ifdef WIN32 
-	_wfopen_s(&pFile, ILibUTF8ToWide(filename, -1), L"abN");
-#else
-	pFile = fopen(filename, "ab");
-#endif
+	pFile = ILibFile_Open(filename, "ab");
 
 	if (pFile != NULL)
 	{
@@ -326,11 +314,7 @@ size_t __fastcall util_readfile(char* filename, char** data, size_t maxlen)
 	size_t r = 1;
 	if (filename == NULL) return 0;
 
-#ifdef WIN32 
-	_wfopen_s(&pFile, ILibUTF8ToWide(filename, -1), L"rbN");
-#else
-	pFile = fopen(filename, "rb");
-#endif
+	pFile = ILibFile_Open(filename, "rb");
 
 	if (pFile != NULL)
 	{
@@ -366,7 +350,7 @@ int __fastcall util_readfile2(char* filename, char** data)
 	*data = NULL;
 	if (filename == NULL) return 0;
 
-	pFile = fopen(filename, "rb");
+	pFile = ILibFile_Open(filename, "rb");
 	if (pFile != NULL)
 	{
 		*data = malloc(1024);
@@ -503,7 +487,7 @@ void __fastcall util_openssl_init()
 	// Add more random seeding in Linux (May be overkill since OpenSSL already uses /dev/urandom)
 #ifdef _POSIX
 	// Under Linux we use "/dev/urandom" if available. This is the best source of random on Linux & variants
-	FILE *pFile = fopen("/dev/urandom", "rb");
+	FILE *pFile = ILibFile_Open("/dev/urandom", "rb");
 	if (pFile != NULL)
 	{
 		l = (int)fread(tbuf, 1, 64, pFile);
@@ -1050,11 +1034,7 @@ int __fastcall util_from_pem(char* filename, struct util_cert* cert)
 	FILE *pFile = NULL;
 
 	if (filename == NULL) return -1;
-#ifdef WIN32 
-	_wfopen_s(&pFile, ILibUTF8ToWide(filename, -1), L"rbN");
-#else
-	pFile = fopen(filename, "rb");
-#endif
+	pFile = ILibFile_Open(filename, "rb");
 	if (pFile == NULL) goto error;
 
 	if ((cert->pkey = PEM_read_PrivateKey(pFile, NULL, 0, NULL)) == NULL) goto error;

--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -9564,7 +9564,7 @@ FILE* ILibFile_Open(char *path, char *mode)
 	char *p;
 #ifdef WIN32
 	DWORD access, disposition;
-	int oflags = _O_NOINHERIT, fd;
+	int oflags = _O_NOINHERIT, fd, update;
 	HANDLE h;
 	char *fmode;
 #endif
@@ -9581,14 +9581,17 @@ FILE* ILibFile_Open(char *path, char *mode)
 #ifdef WIN32
 	switch (mode[0])
 	{
-		case 'r': access = GENERIC_READ;  disposition = OPEN_EXISTING; break;
-		case 'w': access = GENERIC_WRITE; disposition = CREATE_ALWAYS; break;
-		default:  access = GENERIC_WRITE; disposition = OPEN_ALWAYS; oflags |= _O_APPEND; break;
+		case 'r': access = FILE_GENERIC_READ;  disposition = OPEN_EXISTING; break;
+		case 'w': access = FILE_GENERIC_WRITE; disposition = CREATE_ALWAYS; break;
+		default:  access = FILE_GENERIC_WRITE; disposition = OPEN_ALWAYS; oflags |= _O_APPEND; break;
 	}
-	if (strchr(mode, '+') != NULL) { access = GENERIC_READ | GENERIC_WRITE; }
+	update = (strchr(mode, '+') != NULL);
+	if (update != 0) { access = FILE_GENERIC_READ | FILE_GENERIC_WRITE; }
 	if (strchr(mode, 'x') != NULL) { disposition = CREATE_NEW; }
+	// FILE_APPEND_DATA without FILE_WRITE_DATA makes the kernel place every write at the end, so two appending processes cannot interleave into each other's data.
+	if (mode[0] == 'a') { access = (access & ~FILE_WRITE_DATA) | FILE_APPEND_DATA; }
 
-	fmode = (access == (GENERIC_READ | GENERIC_WRITE)) ? "r+b" : (mode[0] == 'r' ? "rb" : "wb");
+	fmode = update != 0 ? "r+b" : (mode[0] == 'r' ? "rb" : "wb");
 
 	// _O_NOINHERIT is still needed next to the NULL security attributes, because _spawn and _exec copy every CRT descriptor without it into the child's CRT table (lpReserved2) even when the OS handle cannot be inherited.
 	h = CreateFileW(ILibUTF8ToWide(path, -1), access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, disposition, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/microstack/ILibParsers.c
+++ b/microstack/ILibParsers.c
@@ -59,6 +59,9 @@ limitations under the License.
 #define _CRTDBG_MAP_ALLOC
 #include <crtdbg.h>
 #endif
+#ifdef WIN32
+#include <io.h>
+#endif
 
 #ifdef WIN32
 	#include <winsock2.h>
@@ -9538,6 +9541,67 @@ char *ILibString_ToLower(const char *inString, size_t length)
 	ILibToLower(inString, length, RetVal);
 	return RetVal;
 }
+
+// https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fsopen-wfsopen?view=msvc-170
+// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+// https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=msvc-170
+// https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fdopen-wfdopen?view=msvc-170
+// https://nodejs.org/docs/latest/api/fs.html#file-system-flags
+// Open file like Node does (opens every file binary, shared for read, write and delete, and non-inheritable by child processes)
+// and accept only r(ead), w(rite), a(ppend), +(read and write), x(fail if exists) for mode.
+// POSIX supports this out of the box, except non-inheritable, which is the fcntl(FD_CLOEXEC) after the fopen.
+// 'rx' is refused with EINVAL on every platform, as Node doesn't have that mode.
+// On windows, _wfopen_s and _wfsopen() lack FILE_SHARE_DELETE, so to circumvent that and get the Node functionality,
+// the handle is made with CreateFileW (which does accept all share flags), get a filedescriptor with _open_osfhandle() and put into FILE* f afterwards.
+// 'N' in mode should give a EINVAL, but is ignored for compatibility, and non-inheritable is forced anyway for Node compliance through NULL in the securityAttributes of CreateFileW() and _O_NOINHERIT
+// Binary is also forced (b in mode and no _O_TEXT in oflags for _open_osfhandle()), POSIX is always binary
+// CRT is stricter in the mode letters (no ax for example), and mode can be reduced to 3 variants (r+b, rb, wb), because the other attributes are sent through access/disposition/o_flags.
+// 'x' becomes CREATE_NEW, which makes CreateFileW fail if the file exists.
+
+FILE* ILibFile_Open(char *path, char *mode)
+{
+	FILE *f = NULL;
+	char *p;
+#ifdef WIN32
+	DWORD access, disposition;
+	int oflags = _O_NOINHERIT, fd;
+	HANDLE h;
+	char *fmode;
+#endif
+
+	if (mode[0] != 'r' && mode[0] != 'w' && mode[0] != 'a') { errno = EINVAL; return(NULL); }
+	for (p = mode + 1; *p != 0; ++p)
+	{
+		if (*p == '+' || *p == 'b' || *p == 'N') { continue; }
+		if (*p == 'x' && mode[0] != 'r') { continue; }
+		errno = EINVAL;
+		return(NULL);
+	}
+
+#ifdef WIN32
+	switch (mode[0])
+	{
+		case 'r': access = GENERIC_READ;  disposition = OPEN_EXISTING; break;
+		case 'w': access = GENERIC_WRITE; disposition = CREATE_ALWAYS; break;
+		default:  access = GENERIC_WRITE; disposition = OPEN_ALWAYS; oflags |= _O_APPEND; break;
+	}
+	if (strchr(mode, '+') != NULL) { access = GENERIC_READ | GENERIC_WRITE; }
+	if (strchr(mode, 'x') != NULL) { disposition = CREATE_NEW; }
+
+	fmode = (access == (GENERIC_READ | GENERIC_WRITE)) ? "r+b" : (mode[0] == 'r' ? "rb" : "wb");
+
+	// _O_NOINHERIT is still needed next to the NULL security attributes, because _spawn and _exec copy every CRT descriptor without it into the child's CRT table (lpReserved2) even when the OS handle cannot be inherited.
+	h = CreateFileW(ILibUTF8ToWide(path, -1), access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, disposition, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (h == INVALID_HANDLE_VALUE) { return(NULL); }
+	if ((fd = _open_osfhandle((intptr_t)h, oflags)) == -1) { CloseHandle(h); return(NULL); }
+	if ((f = _fdopen(fd, fmode)) == NULL) { _close(fd); return(NULL); }	// _close() also closes the handle
+#else
+	f = fopen(path, mode);
+	if (f != NULL) { fcntl(fileno(f), F_SETFD, FD_CLOEXEC); }
+#endif
+	return(f);
+}
+
 /*! \fn ILibReadFileFromDiskEx(char **Target, char *FileName)
 \brief Reads a file into a char *
 \par
@@ -9552,11 +9616,7 @@ int ILibReadFileFromDiskEx(char **Target, char *FileName)
 	int SourceFileLength = 0;
 	FILE *SourceFile = NULL;
 
-#ifdef WIN32
-	_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"rb");
-#else
-	SourceFile = fopen(FileName, "rb");
-#endif
+	SourceFile = ILibFile_Open(FileName, "rb");
 	if (SourceFile == NULL) { *Target = NULL; return 0; }
 
 	fseek(SourceFile, 0, SEEK_END);
@@ -9612,11 +9672,7 @@ void ILibWriteStringToDiskEx(char *FileName, char *data, int dataLen)
 {
 	FILE *SourceFile = NULL;
 
-#ifdef WIN32
-	_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"wb");
-#else
-	SourceFile = fopen(FileName, "wb");
-#endif
+	SourceFile = ILibFile_Open(FileName, "wb");
 	
 	if (SourceFile != NULL)
 	{
@@ -9628,11 +9684,7 @@ void ILibAppendStringToDiskEx2(char *FileName, char *data, int dataLen, uint64_t
 {
 	FILE *SourceFile = NULL;
 
-#ifdef WIN32
-	_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"ab");
-#else
-	SourceFile = fopen(FileName, "ab");
-#endif
+	SourceFile = ILibFile_Open(FileName, "ab");
 	
 	if (SourceFile != NULL)
 	{
@@ -9675,11 +9727,7 @@ void ILibAppendStringToDiskEx3(char *FileName, char *data, int dataLen, uint64_t
 
 	if (maxSize == 0) { ILibAppendStringToDiskEx2(FileName, data, dataLen, 0); return; } // 0 == unbounded, no cap policy to apply
 
-#ifdef WIN32
-	_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"ab");
-#else
-	SourceFile = fopen(FileName, "ab");
-#endif
+	SourceFile = ILibFile_Open(FileName, "ab");
 	if (SourceFile == NULL) { return; }
 
 	fseek(SourceFile, 0, SEEK_END);
@@ -9713,11 +9761,7 @@ void ILibAppendStringToDiskEx3(char *FileName, char *data, int dataLen, uint64_t
 	if (capMode == ILibAppendStringToDisk_Cap_Truncate)
 	{
 		fclose(SourceFile);
-#ifdef WIN32
-		_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"wb");
-#else
-		SourceFile = fopen(FileName, "wb");
-#endif
+		SourceFile = ILibFile_Open(FileName, "wb");
 		if (SourceFile != NULL)
 		{
 			if (fwrite(data, sizeof(char), dataLen, SourceFile)) {}
@@ -9742,11 +9786,7 @@ void ILibAppendStringToDiskEx3(char *FileName, char *data, int dataLen, uint64_t
 		sprintf_s(rotateTo, sizeof(rotateTo), "%s.1", FileName);
 		ILibRenameFileOnDisk(FileName, rotateTo);
 
-#ifdef WIN32
-		_wfopen_s(&SourceFile, ILibUTF8ToWide(FileName, -1), L"ab");
-#else
-		SourceFile = fopen(FileName, "ab");
-#endif
+		SourceFile = ILibFile_Open(FileName, "ab");
 		if (SourceFile != NULL)
 		{
 			if (fwrite(data, sizeof(char), dataLen, SourceFile)) {}
@@ -9795,8 +9835,8 @@ int ILibFile_CopyTo(char *source, char *destination)
 	ILibUTF8ToWideEx(destination, -1, DestW, (int)sizeof(DestW) / 2);
 	return(CopyFileW(SourceW, DestW, FALSE) ? 0 : 1);
 #else
-	FILE *from = fopen(source, "rb");
-	FILE *to = fopen(destination, "wb");
+	FILE *from = ILibFile_Open(source, "rb");
+	FILE *to = ILibFile_Open(destination, "wb");
 	size_t bytesRead;
 	int ret = 0;
 	while ((bytesRead = fread(ILibScratchPad, 1, sizeof(ILibScratchPad), from)) > 0)
@@ -11341,11 +11381,7 @@ void ILibLinkedList_FileBacked_Reset(ILibLinkedList_FileBacked_Root *root)
 	FILE* source = (FILE*)ptr[0];
 	fclose(source);
 	source = NULL;
-#ifdef WIN32
-	_wfopen_s(&source, ILibUTF8ToWide((char*)ptr[1], -1), L"wb+N");
-#else
-	source = fopen((char*)ptr[1], "wb+");
-#endif
+	source = ILibFile_Open((char*)ptr[1], "wb+");
 	ptr[0] = source;
 	root->head = root->tail = 0;
 	ILibLinkedList_FileBacked_SaveRoot(root);
@@ -11415,17 +11451,10 @@ ILibLinkedList_FileBacked_Root* ILibLinkedList_FileBacked_Create(char* path, uns
 	FILE* source;
 	ILibLinkedList_FileBacked_Root *retVal = NULL;
 
-#ifdef WIN32
-	if (_wfopen_s(&source, ILibUTF8ToWide(path, -1), L"rb+N") != 0)
+	if ((source = ILibFile_Open(path, "rb+")) == NULL)
 	{
-		_wfopen_s(&source, ILibUTF8ToWide(path, -1), L"wb+N");
+		source = ILibFile_Open(path, "wb+");
 	}
-#else
-	if ((source = fopen(path, "rb+")) == NULL)
-	{
-		source = fopen(path, "wb+");
-	}
-#endif
 	
 	if (source == NULL) { return(NULL); }
 

--- a/microstack/ILibParsers.h
+++ b/microstack/ILibParsers.h
@@ -963,6 +963,7 @@ int ILibIsRunningOnChainThread(void* chain);
 		struct ILibXMLAttribute *Next;	// Next Attribute
 	};
 
+	FILE* ILibFile_Open(char *path, char *mode);
 	char *ILibReadFileFromDisk(char *FileName);
 	int ILibReadFileFromDiskEx(char **Target, char *FileName);
 	void ILibWriteStringToDisk(char *FileName, char *data);

--- a/microstack/ILibSimpleDataStore.c
+++ b/microstack/ILibSimpleDataStore.c
@@ -509,56 +509,34 @@ FILE* ILibSimpleDataStore_OpenFileEx3(char* filePath, int forceTruncateIfNonZero
 {
 	FILE* f = NULL;
 	if (created != NULL) { *created = 0; }
-
-#ifdef WIN32
-	if (readonly == 0)
-	{
-		HANDLE h = NULL;
-		if (forceTruncateIfNonZero != 0)
-		{
-			h = CreateFileW(ILibUTF8ToWide(filePath, -1), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, TRUNCATE_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-			if (h == INVALID_HANDLE_VALUE && GetLastError() == ERROR_FILE_NOT_FOUND)
-			{
-				if (created != NULL) { *created = 1; }
-				h = CreateFileW(ILibUTF8ToWide(filePath, -1), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
-			}
-		}
-		else
-		{
-			h = CreateFileW(ILibUTF8ToWide(filePath, -1), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-			if (h == INVALID_HANDLE_VALUE && GetLastError() == ERROR_FILE_NOT_FOUND)
-			{
-				if (created != NULL) { *created = 1; }
-				h = CreateFileW(ILibUTF8ToWide(filePath, -1), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
-			}
-		}
-		int fd = _open_osfhandle((intptr_t)h, _O_RDWR);
-		if (fd == -1) { CloseHandle(h); return(NULL); }
-		f = _fdopen(fd, "wb+N");
-		if (f == NULL) { CloseHandle(h); return(NULL); }
-	}
-	else
-	{
-		HANDLE h = CreateFileW(ILibUTF8ToWide(filePath, -1), GENERIC_READ, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-		if (h == INVALID_HANDLE_VALUE) { return(NULL); }
-		int fd = _open_osfhandle((intptr_t)h, _O_RDONLY);
-		if (fd == -1) { CloseHandle(h); return(NULL); }
-		f = _fdopen(fd, "rb");
-		if (f == NULL) { CloseHandle(h); return(NULL); }
-	}
-#else
-	char *flag = readonly == 0 ? "rb+": "rb";
-
-	if (forceTruncateIfNonZero != 0 || (f = fopen(filePath, flag)) == NULL)
+	if (readonly != 0) { return(ILibFile_Open(filePath, "rb")); }
+	
+	// forceTruncateIfNonZero: start from an empty file instead of the existing one. Only compacting uses it for its .tmp copy
+	if (forceTruncateIfNonZero == 0) { f = ILibFile_Open(filePath, "rb+"); }
+	if (f == NULL)
 	{
 		if (created != NULL) { *created = 1; }
-		f = fopen(filePath, "wb+");
+		// x makes a second agent racing on a missing file fail with EEXIST instead of truncating the store the first one just created.
+		f = ILibFile_Open(filePath, forceTruncateIfNonZero != 0 ? "wb+" : "wb+x");
 	}
-	if (f == NULL) { return NULL; } // If we failed to open the file, stop now.
-	if (readonly == 0 && flock(fileno(f), LOCK_EX | LOCK_NB) != 0) { fclose(f); return NULL; } // Request exclusive lock on this file, no blocking.
-#endif
+	if (f == NULL) { return(NULL); }
 
-	return f;
+	// One writer, readers allowed
+	#ifdef WIN32
+	{
+		// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
+		// A windows lock is mandatory, covers a byte range and a reader can only read outside that locked range.
+		// Lock one byte past any offset the store can use, so readers aren't blocked.
+		OVERLAPPED ov = { 0 };
+		ov.Offset = 0xFFFFFFFF; ov.OffsetHigh = 0x7FFFFFFF;
+		if (!LockFileEx((HANDLE)_get_osfhandle(_fileno(f)), LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &ov)) { fclose(f); return(NULL); }
+	}
+#else
+	// On POSIX a lock is advisory, so readers can read regardless
+	// LOCK_EX: exclusive lock, LOCK_NB:nonblocking request (don't wait for a lock)
+	if (flock(fileno(f), LOCK_EX | LOCK_NB) != 0) { fclose(f); return(NULL); }
+#endif
+	return(f);
 }
 #define ILibSimpleDataStore_OpenFile(filePath) ILibSimpleDataStore_OpenFileEx2(filePath, 0, 0)
 #define ILibSimpleDataStore_OpenFileEx(filePath, forceTruncate) ILibSimpleDataStore_OpenFileEx2(filePath, forceTruncate, 0)


### PR DESCRIPTION
# Summary

All fileopens now go through a shared function which checks the mode and opens files like Node does:
opens every file binary, shared for read, write and delete, non-inheritable by child processes and accept only r(ead), w(rite), a(ppend), +(read and write), x(fail if exists) for mode.

POSIX supports this out of the box (Node's fs is modelled after POSIX after all), except non-inheritable, which is the fcntl(FD_CLOEXEC) after the fopen.
'rx' is refused with EINVAL on every platform, as Node doesn't have that mode.
On windows, _wfopen_s and _wfsopen() lack FILE_SHARE_DELETE, so to circumvent that and get the Node functionality,
the handle is made with CreateFileW (which does accept all share flags), get a filedescriptor with _open_osfhandle() and put into FILE* f afterwards.

This should fix most sharing violation issues on windows.

#edit 10-09: add datastore fix
This is related to the fileopen fix. By using the new ILibFile_Open function for opening the datastore (the local .db), it no longer is passed on to child precesses. If the agent restarted and a chil process was still running, holding a lock on the.db, this would cause the meshagent to open an empty, cache-only .db and create an new certificate. And a new id on the meshserver side.

- Relates to #372 and meshcentral #[7832](https://github.com/Ylianst/MeshCentral/issues/7832)
<details>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🛠️ I have self-reviewed my code and self-tested it against a MeshCentral server to ensure it works as expected.
- [x] 🖥️ My change compiles on every platform it affects (Windows / Linux / macOS / FreeBSD), and I have considered
      the impact on platforms and architectures I could not test.
- [ ] 📦 If I changed JavaScript modules under `modules/`, I re-embedded them so the compiled-in copies in
      `microscript/ILibDuktape_Polyfills.c` match (the agent runs the embedded copies, not the files on disk).
- [x] 🤖 I ran the agent self-test where appropriate (see "Self Test" in [readme.md](../readme.md)).
- [ ] 📄 Documentation updates are included (if applicable), e.g. the `.msh` options table in [readme.md](../readme.md).
- [ ] 🧰 Updates to vendored dependencies (OpenSSL, zlib, ...) are listed and explained.
- [ ] ⚠️ CI passes and is green (Windows / Linux / macOS / FreeBSD builds and CodeQL).

</details>

## Testing

Tested on linux x86/x64 and windows x86/x64

Powershell test as mentioned in #7832 works, I can open edit, download and copy the file.

#edit 10-09: datastore tests done - push new core, service restart, force agent update on linux/windows.